### PR TITLE
feat: per-transcription instrumentation (Milestone 1)

### DIFF
--- a/src/audio/converter.ts
+++ b/src/audio/converter.ts
@@ -57,7 +57,7 @@ export async function convertAudio(inputBuffer: Buffer): Promise<Buffer> {
 				const outputBuffer = Buffer.concat(chunks);
 				const outputSize = outputBuffer.length;
 				const duration = Date.now() - startTime;
-				logger.info(
+				logger.debug(
 					{
 						inputSize,
 						outputSize,

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -40,6 +40,7 @@ type AudioFormatStrategy = "opus" | "raw";
 interface TranscriptionMetrics {
 	// Timings (ms, -1 = skipped)
 	totalMs: number;
+	processingMs: number; // user-perceived latency (up to clipboard write)
 	conversionMs: number;
 	groqMs: number;
 	deepgramMs: number;
@@ -694,6 +695,7 @@ export class DaemonService {
 		// Initialize metrics with defaults
 		const metrics: TranscriptionMetrics = {
 			totalMs: 0,
+			processingMs: 0,
 			conversionMs: -1,
 			groqMs: -1,
 			deepgramMs: -1,
@@ -903,6 +905,7 @@ export class DaemonService {
 			// bookkeeping — their latency is tracked separately in historyAppendMs /
 			// notificationEnqueueMs and included in totalMs but not processingTime.
 			const processingTime = Date.now() - totalStart;
+			metrics.processingMs = processingTime;
 
 			// --- Stage: Stats write ---
 			const statsTimed = await timeAsync(() => incrementTranscriptionCount());

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -873,7 +873,7 @@ export class DaemonService {
 			} else {
 				finalText = groqText || deepgramText;
 				metrics.mergeStrategy = "single_source";
-				metrics.mergeMs = 0;
+				metrics.mergeMs = -1;
 
 				const failedService = !groqText ? "Groq" : "Deepgram";
 				const error = !groqText ? groqErr : deepgramErr;
@@ -913,6 +913,10 @@ export class DaemonService {
 						: "deepgram";
 			metrics.engine = engineUsed;
 
+			// processingTime captures user-perceived latency (up to clipboard write).
+			// This excludes history append and notification which are fire-and-forget
+			// bookkeeping after the user already has the transcription.
+			// Contrast with metrics.totalMs which includes all pipeline stages.
 			const processingTime = Date.now() - totalStart;
 			const historyTimed = await timeAsync(() =>
 				appendHistory({

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -898,6 +898,12 @@ export class DaemonService {
 			);
 			metrics.clipboardMs = clipboardTimed.durationMs;
 
+			// processingTime captures user-perceived latency (up to clipboard write).
+			// This excludes history append and notification which are fire-and-forget
+			// bookkeeping after the user already has the transcription.
+			// Contrast with metrics.totalMs which includes all pipeline stages.
+			const processingTime = Date.now() - totalStart;
+
 			// --- Stage: Stats write ---
 			const statsTimed = await timeAsync(() => incrementTranscriptionCount());
 			metrics.statsWriteMs = statsTimed.durationMs;
@@ -913,11 +919,6 @@ export class DaemonService {
 						: "deepgram";
 			metrics.engine = engineUsed;
 
-			// processingTime captures user-perceived latency (up to clipboard write).
-			// This excludes history append and notification which are fire-and-forget
-			// bookkeeping after the user already has the transcription.
-			// Contrast with metrics.totalMs which includes all pipeline stages.
-			const processingTime = Date.now() - totalStart;
 			const historyTimed = await timeAsync(() =>
 				appendHistory({
 					timestamp: new Date().toISOString(),
@@ -949,7 +950,7 @@ export class DaemonService {
 					engine: engineUsed,
 					textLength: finalText.length,
 					recordingDurationMs: duration,
-					processingMs: metrics.totalMs,
+					processingMs: processingTime,
 					mergeStrategy: metrics.mergeStrategy,
 					...(accuracy ? { mergeConfidence: accuracy.confidence } : {}),
 				},

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -899,9 +899,9 @@ export class DaemonService {
 			metrics.clipboardMs = clipboardTimed.durationMs;
 
 			// processingTime captures user-perceived latency (up to clipboard write).
-			// This excludes history append and notification which are fire-and-forget
-			// bookkeeping after the user already has the transcription.
-			// Contrast with metrics.totalMs which includes all pipeline stages.
+			// The stages below (history + notification) are awaited but post-clipboard
+			// bookkeeping — their latency is tracked separately in historyAppendMs /
+			// notificationEnqueueMs and included in totalMs but not processingTime.
 			const processingTime = Date.now() - totalStart;
 
 			// --- Stage: Stats write ---

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -14,9 +14,14 @@ import { DeepgramTranscriber } from "../transcribe/deepgram";
 import {
 	DeepgramStreamingTranscriber,
 	type StreamingFailureReason,
+	type StreamingStopReason,
 } from "../transcribe/deepgram-streaming";
 import { GroqClient } from "../transcribe/groq";
-import { type MergeResult, TranscriptMerger } from "../transcribe/merger";
+import {
+	type MergeResult,
+	type MergeStrategy,
+	TranscriptMerger,
+} from "../transcribe/merger";
 import { ErrorTemplates, formatUserError } from "../utils/error-templates";
 import { errorIncludes, getErrorCode } from "../utils/errors";
 import { appendHistory } from "../utils/history";
@@ -27,6 +32,48 @@ import { HotkeyListener } from "./hotkey";
 import { getIPCServer, type IPCServer } from "./ipc";
 
 const HALLUCINATION_MAX_CHARS = 20;
+
+// --- Instrumentation types ---
+
+type AudioFormatStrategy = "opus" | "raw";
+
+interface TranscriptionMetrics {
+	// Timings (ms, -1 = skipped)
+	totalMs: number;
+	conversionMs: number;
+	groqMs: number;
+	deepgramMs: number;
+	mergeMs: number;
+	clipboardMs: number;
+	statsWriteMs: number;
+	historyAppendMs: number;
+	notificationEnqueueMs: number;
+
+	// Input characteristics
+	rawAudioBytes: number;
+	recordingDurationMs: number;
+	convertedAudioBytes: number;
+
+	// Decisions
+	streamingEnabled: boolean;
+	audioFormatStrategy: AudioFormatStrategy;
+	mergeStrategy: MergeStrategy | "skip_no_speech" | "skip_hallucination";
+	deepgramStopReason: StreamingStopReason | null;
+
+	// Outcome
+	engine: string;
+	textLength: number;
+	groqTextLength: number;
+	deepgramTextLength: number;
+}
+
+async function timeAsync<T>(
+	fn: () => Promise<T>,
+): Promise<{ result: T; durationMs: number }> {
+	const start = Date.now();
+	const result = await fn();
+	return { result, durationMs: Date.now() - start };
+}
 
 export interface DaemonState {
 	status: DaemonStatus;
@@ -642,53 +689,102 @@ export class DaemonService {
 	}
 
 	private async processAudio(audioBuffer: Buffer, duration: number) {
+		const totalStart = Date.now();
+
+		// Initialize metrics with defaults
+		const metrics: TranscriptionMetrics = {
+			totalMs: 0,
+			conversionMs: -1,
+			groqMs: -1,
+			deepgramMs: -1,
+			mergeMs: -1,
+			clipboardMs: -1,
+			statsWriteMs: -1,
+			historyAppendMs: -1,
+			notificationEnqueueMs: -1,
+			rawAudioBytes: audioBuffer.length,
+			recordingDurationMs: duration,
+			convertedAudioBytes: -1,
+			streamingEnabled: !!this.config.transcription.streaming,
+			audioFormatStrategy: "opus",
+			mergeStrategy: "skip_no_speech",
+			deepgramStopReason: null,
+			engine: "",
+			textLength: 0,
+			groqTextLength: 0,
+			deepgramTextLength: 0,
+		};
+
 		try {
 			const language = this.config.transcription.language;
 			const boostWords = this.config.transcription.boostWords || [];
 
-			const startTime = Date.now();
-			const convertedBuffer = await convertAudio(audioBuffer);
+			// --- Stage: Audio conversion ---
+			const conversion = await timeAsync(() => convertAudio(audioBuffer));
+			const convertedBuffer = conversion.result;
+			metrics.conversionMs = conversion.durationMs;
+			metrics.convertedAudioBytes = convertedBuffer.length;
 
-			let groqErr: any = null;
-			let deepgramErr: any = null;
-
+			// --- Stage: Parallel transcription ---
+			let groqErr: unknown = null;
+			let deepgramErr: unknown = null;
 			let groqText = "";
 			let deepgramText = "";
-
 			let streamingChunkCount = -1;
 
 			if (this.config.transcription.streaming && this.deepgramStreaming) {
-				const [groqResult, streamingResult] = await Promise.all([
-					this.groq
-						.transcribe(convertedBuffer, language, boostWords)
-						.catch((err) => {
-							groqErr = err;
-							return "";
+				const [groqTimed, deepgramTimed] = await Promise.all([
+					timeAsync(() =>
+						this.groq
+							.transcribe(convertedBuffer, language, boostWords)
+							.catch((err) => {
+								groqErr = err;
+								return "";
+							}),
+					),
+					timeAsync(() =>
+						this.deepgramStreaming!.stop().catch((err) => {
+							deepgramErr = err;
+							return {
+								text: "",
+								chunkCount: -1,
+								stopReason: "not_connected" as const,
+							};
 						}),
-					this.deepgramStreaming.stop().catch((err) => {
-						deepgramErr = err;
-						return { text: "", chunkCount: -1 };
-					}),
+					),
 				]);
-				groqText = groqResult;
+				metrics.groqMs = groqTimed.durationMs;
+				metrics.deepgramMs = deepgramTimed.durationMs;
+				groqText = groqTimed.result;
+				const streamingResult = deepgramTimed.result;
 				deepgramText = streamingResult.text;
 				streamingChunkCount = streamingResult.chunkCount;
+				metrics.deepgramStopReason = streamingResult.stopReason;
 			} else {
-				[groqText, deepgramText] = await Promise.all([
-					this.groq
-						.transcribe(convertedBuffer, language, boostWords)
-						.catch((err) => {
-							groqErr = err;
+				const [groqTimed, deepgramTimed] = await Promise.all([
+					timeAsync(() =>
+						this.groq
+							.transcribe(convertedBuffer, language, boostWords)
+							.catch((err) => {
+								groqErr = err;
+								return "";
+							}),
+					),
+					timeAsync(() =>
+						this.deepgram.transcribe(convertedBuffer, language).catch((err) => {
+							deepgramErr = err;
 							return "";
 						}),
-					this.deepgram.transcribe(convertedBuffer, language).catch((err) => {
-						deepgramErr = err;
-						return "";
-					}),
+					),
 				]);
+				metrics.groqMs = groqTimed.durationMs;
+				metrics.deepgramMs = deepgramTimed.durationMs;
+				groqText = groqTimed.result;
+				deepgramText = deepgramTimed.result;
 			}
 
-			const processingTime = Date.now() - startTime;
+			metrics.groqTextLength = groqText.length;
+			metrics.deepgramTextLength = deepgramText.length;
 
 			const handleTranscriptionError = (
 				err: unknown,
@@ -720,6 +816,7 @@ export class DaemonService {
 				}
 			};
 
+			// --- Early exits (no speech / hallucination) ---
 			if (!groqText && !deepgramText) {
 				if (!groqErr && !deepgramErr) {
 					logger.info({ duration }, "No speech detected in recording");
@@ -747,8 +844,9 @@ export class DaemonService {
 				groqText &&
 				groqText.length < HALLUCINATION_MAX_CHARS
 			) {
+				metrics.mergeStrategy = "skip_hallucination";
 				logger.info(
-					{ groqText, streamingChunkCount },
+					{ groqTextLength: groqText.length, streamingChunkCount },
 					"Filtered Groq hallucination on silent audio",
 				);
 				notify(
@@ -760,15 +858,22 @@ export class DaemonService {
 				return;
 			}
 
+			// --- Stage: Merge ---
 			let finalText = "";
 			let accuracy: MergeResult["accuracy"] | undefined;
 
 			if (groqText && deepgramText) {
-				const mergeResult = await this.merger.merge(groqText, deepgramText);
-				finalText = mergeResult.text;
-				accuracy = mergeResult.accuracy;
+				const mergeTimed = await timeAsync(() =>
+					this.merger.merge(groqText, deepgramText),
+				);
+				metrics.mergeMs = mergeTimed.durationMs;
+				finalText = mergeTimed.result.text;
+				accuracy = mergeTimed.result.accuracy;
+				metrics.mergeStrategy = mergeTimed.result.strategy;
 			} else {
 				finalText = groqText || deepgramText;
+				metrics.mergeStrategy = "single_source";
+				metrics.mergeMs = 0;
 
 				const failedService = !groqText ? "Groq" : "Deepgram";
 				const error = !groqText ? groqErr : deepgramErr;
@@ -787,52 +892,68 @@ export class DaemonService {
 				throw new Error("No transcription generated");
 			}
 
-			await this.clipboard.append(finalText);
+			// --- Stage: Clipboard ---
+			const clipboardTimed = await timeAsync(() =>
+				this.clipboard.append(finalText),
+			);
+			metrics.clipboardMs = clipboardTimed.durationMs;
 
-			const stats = await incrementTranscriptionCount();
-			this.transcriptionCountToday = stats.today;
-			this.transcriptionCountTotal = stats.total;
+			// --- Stage: Stats write ---
+			const statsTimed = await timeAsync(() => incrementTranscriptionCount());
+			metrics.statsWriteMs = statsTimed.durationMs;
+			this.transcriptionCountToday = statsTimed.result.today;
+			this.transcriptionCountTotal = statsTimed.result.total;
 
+			// --- Stage: History append ---
 			const engineUsed =
 				groqText && deepgramText
 					? "groq+deepgram"
 					: groqText
 						? "groq"
 						: "deepgram";
-			await appendHistory({
-				timestamp: new Date().toISOString(),
-				text: finalText,
-				duration,
-				engine: engineUsed,
-				processingTime,
-			});
+			metrics.engine = engineUsed;
 
-			this.notifyStateChange(
-				"Success",
-				"Transcription copied to clipboard",
-				"success",
+			const processingTime = Date.now() - totalStart;
+			const historyTimed = await timeAsync(() =>
+				appendHistory({
+					timestamp: new Date().toISOString(),
+					text: finalText,
+					duration,
+					engine: engineUsed,
+					processingTime,
+				}),
 			);
+			metrics.historyAppendMs = historyTimed.durationMs;
 
+			// --- Stage: Notification ---
+			const notifyTimed = await timeAsync(async () =>
+				this.notifyStateChange(
+					"Success",
+					"Transcription copied to clipboard",
+					"success",
+				),
+			);
+			metrics.notificationEnqueueMs = notifyTimed.durationMs;
+
+			// --- Finalize metrics ---
+			metrics.totalMs = Date.now() - totalStart;
+			metrics.textLength = finalText.length;
+
+			// --- Outcome log (no full text) ---
 			logger.info(
 				{
-					duration,
-					processingTime,
-					text: finalText,
+					engine: engineUsed,
 					textLength: finalText.length,
-					groqText,
-					groqTextLength: groqText.length,
-					deepgramText,
-					deepgramTextLength: deepgramText.length,
-					models:
-						groqText && deepgramText
-							? "groq+deepgram+llama"
-							: groqText
-								? "groq"
-								: "deepgram",
-					accuracy,
+					recordingDurationMs: duration,
+					processingMs: metrics.totalMs,
+					mergeStrategy: metrics.mergeStrategy,
+					...(accuracy ? { mergeConfidence: accuracy.confidence } : {}),
 				},
 				"Transcription complete",
 			);
+
+			// --- Performance log (structured, filterable) ---
+			logger.info({ type: "perf", ...metrics }, "Transcription performance");
 		} catch (error: unknown) {
 			logError("Processing failed", error, { duration });
 

--- a/src/output/clipboard.ts
+++ b/src/output/clipboard.ts
@@ -36,7 +36,7 @@ export class ClipboardManager {
 	public async append(text: string): Promise<void> {
 		try {
 			await this.write(text);
-			logger.info("Clipboard updated successfully");
+			logger.debug("Clipboard updated successfully");
 		} catch (error) {
 			logger.error("Clipboard write failed, falling back to file");
 			await this.saveToFallbackFile(text);

--- a/src/output/notification.ts
+++ b/src/output/notification.ts
@@ -30,7 +30,7 @@ export const notify = (
 			wait: false,
 		});
 
-		logger.info({ title, message, type }, "Notification sent");
+		logger.debug({ title, message, type }, "Notification sent");
 	} catch (error) {
 		logger.error({ err: error }, "Failed to send notification");
 	}

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -12,7 +12,6 @@ import { logError, logger } from "../utils/logger";
 export type StreamingStopReason =
 	| "finalize_transcript"
 	| "finalize_timeout"
-	| "close_event"
 	| "close_timeout"
 	| "not_connected";
 
@@ -295,25 +294,23 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 				// Now close the connection
 				this.connection.requestClose();
 
-				const closeReason = await new Promise<StreamingStopReason>(
-					(resolve) => {
-						const timeout = setTimeout(() => {
-							logger.warn(
-								"Deepgram close timeout, proceeding with available transcripts",
-							);
-							resolve("close_timeout");
-						}, 2000);
+				const closeClean = await new Promise<boolean>((resolve) => {
+					const timeout = setTimeout(() => {
+						logger.warn(
+							"Deepgram close timeout, proceeding with available transcripts",
+						);
+						resolve(false);
+					}, 2000);
 
-						this.once("close", () => {
-							clearTimeout(timeout);
-							resolve("close_event");
-						});
-					},
-				);
+					this.once("close", () => {
+						clearTimeout(timeout);
+						resolve(true);
+					});
+				});
 
 				// Preserve close_timeout explicitly so tail-latency analysis can
 				// distinguish transport shutdown stalls from finalize stalls.
-				if (closeReason === "close_timeout") {
+				if (!closeClean) {
 					stopReason = "close_timeout";
 				}
 			} catch (error) {

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -9,9 +9,17 @@ import {
 import { loadConfig } from "../config/loader";
 import { logError, logger } from "../utils/logger";
 
+export type StreamingStopReason =
+	| "finalize_transcript"
+	| "finalize_timeout"
+	| "close_event"
+	| "close_timeout"
+	| "not_connected";
+
 export interface StreamingResult {
 	text: string;
 	chunkCount: number;
+	stopReason: StreamingStopReason;
 }
 
 export interface StreamingFailureReason {
@@ -83,14 +91,14 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 				if (transcript && transcript.trim().length > 0) {
 					if (data.speech_final) {
 						this.transcriptChunks.push(transcript.trim());
-						logger.info(
+						logger.debug(
 							{ transcript: transcript.trim(), isFinal: true },
 							"Deepgram chunk finalized (speech_final)",
 						);
 						this.emit("transcript", transcript.trim());
 					} else if (data.is_final) {
 						this.transcriptChunks.push(transcript.trim());
-						logger.info(
+						logger.debug(
 							{ transcript: transcript.trim(), isFinal: data.is_final },
 							"Deepgram chunk finalized (is_final)",
 						);
@@ -262,6 +270,8 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 
 	public async stop(): Promise<StreamingResult> {
 		this.isStopping = true;
+		let stopReason: StreamingStopReason = "not_connected";
+
 		if (this.connection) {
 			try {
 				// Flush any buffered audio before closing
@@ -269,15 +279,15 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 				logger.debug("Sent finalize signal to Deepgram");
 
 				// Wait for final transcript after finalize
-				await new Promise<void>((resolve) => {
+				stopReason = await new Promise<StreamingStopReason>((resolve) => {
 					const timeout = setTimeout(() => {
 						logger.debug("Finalize wait timeout, proceeding");
-						resolve();
+						resolve("finalize_timeout");
 					}, 300);
 
 					const transcriptHandler = () => {
 						clearTimeout(timeout);
-						resolve();
+						resolve("finalize_transcript");
 					};
 					this.once("transcript", transcriptHandler);
 				});
@@ -285,19 +295,27 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 				// Now close the connection
 				this.connection.requestClose();
 
-				await new Promise<void>((resolve) => {
-					const timeout = setTimeout(() => {
-						logger.warn(
-							"Deepgram close timeout, proceeding with available transcripts",
-						);
-						resolve();
-					}, 2000);
+				const closeReason = await new Promise<StreamingStopReason>(
+					(resolve) => {
+						const timeout = setTimeout(() => {
+							logger.warn(
+								"Deepgram close timeout, proceeding with available transcripts",
+							);
+							resolve("close_timeout");
+						}, 2000);
 
-					this.once("close", () => {
-						clearTimeout(timeout);
-						resolve();
-					});
-				});
+						this.once("close", () => {
+							clearTimeout(timeout);
+							resolve("close_event");
+						});
+					},
+				);
+
+				// Preserve close_timeout explicitly so tail-latency analysis can
+				// distinguish transport shutdown stalls from finalize stalls.
+				if (closeReason === "close_timeout") {
+					stopReason = "close_timeout";
+				}
 			} catch (error) {
 				logError("Error finishing Deepgram streaming", error);
 			} finally {
@@ -315,14 +333,19 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 		this.audioBuffer = [];
 
 		const finalText = this.transcriptChunks.join(" ").trim();
-		logger.info(
+		logger.debug(
 			{
 				chunkCount: this.transcriptChunks.length,
 				textLength: finalText.length,
+				stopReason,
 			},
 			"Deepgram streaming transcription complete",
 		);
 
-		return { text: finalText, chunkCount: this.transcriptChunks.length };
+		return {
+			text: finalText,
+			chunkCount: this.transcriptChunks.length,
+			stopReason,
+		};
 	}
 }

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -13,6 +13,8 @@ export type StreamingStopReason =
 	| "finalize_transcript"
 	| "finalize_timeout"
 	| "close_timeout"
+	| "finalize_transcript+close_timeout"
+	| "finalize_timeout+close_timeout"
 	| "not_connected";
 
 export interface StreamingResult {
@@ -309,10 +311,11 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 					});
 				});
 
-				// Preserve close_timeout explicitly so tail-latency analysis can
-				// distinguish transport shutdown stalls from finalize stalls.
+				// Preserve close_timeout info using compound value to distinguish:
+				// - "finalize_transcript+close_timeout": finalize worked, transport stalled
+				// - "finalize_timeout+close_timeout": both stages timed out
 				if (!closeClean) {
-					stopReason = "close_timeout";
+					stopReason = `${stopReason}+close_timeout` as StreamingStopReason;
 				}
 			} catch (error) {
 				logError("Error finishing Deepgram streaming", error);

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -12,7 +12,6 @@ import { logError, logger } from "../utils/logger";
 export type StreamingStopReason =
 	| "finalize_transcript"
 	| "finalize_timeout"
-	| "close_timeout"
 	| "finalize_transcript+close_timeout"
 	| "finalize_timeout+close_timeout"
 	| "not_connected";

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -281,6 +281,7 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 				stopReason = await new Promise<StreamingStopReason>((resolve) => {
 					const timeout = setTimeout(() => {
 						logger.debug("Finalize wait timeout, proceeding");
+						this.off("transcript", transcriptHandler);
 						resolve("finalize_timeout");
 					}, 300);
 

--- a/src/transcribe/groq.ts
+++ b/src/transcribe/groq.ts
@@ -85,7 +85,7 @@ export class GroqClient {
 					);
 
 					const text = completion.text.trim();
-					logger.info(
+					logger.debug(
 						{
 							model: "whisper-large-v3",
 							language,

--- a/src/transcribe/merger.ts
+++ b/src/transcribe/merger.ts
@@ -30,8 +30,16 @@ RULES:
 8. Remove false starts and abandoned sentences.
 9. Output ONLY the merged text, no quotes or preamble.`;
 
+export type MergeStrategy =
+	| "exact_match"
+	| "single_source"
+	| "llm"
+	| "llm_fallback"
+	| "empty";
+
 export interface MergeResult {
 	text: string;
+	strategy: MergeStrategy;
 	accuracy: {
 		sourcesMatch: boolean;
 		editDistance: number;
@@ -68,18 +76,21 @@ export class TranscriptMerger {
 		if (!groqText && !deepgramText) {
 			return {
 				text: "",
+				strategy: "empty",
 				accuracy: { sourcesMatch, editDistance: 0, confidence: 0 },
 			};
 		}
 		if (!groqText) {
 			return {
 				text: deepgramText,
+				strategy: "single_source",
 				accuracy: { sourcesMatch, editDistance: 0, confidence: 0.5 },
 			};
 		}
 		if (!deepgramText) {
 			return {
 				text: groqText,
+				strategy: "single_source",
 				accuracy: { sourcesMatch, editDistance: 0, confidence: 0.5 },
 			};
 		}
@@ -87,12 +98,14 @@ export class TranscriptMerger {
 		if (sourcesMatch) {
 			return {
 				text: deepgramText,
+				strategy: "exact_match",
 				accuracy: { sourcesMatch: true, editDistance: 0, confidence: 1 },
 			};
 		}
 
 		const startTime = Date.now();
 		let finalText: string;
+		let mergeStrategy: MergeStrategy = "llm";
 
 		try {
 			const completion = await withRetry(
@@ -126,7 +139,7 @@ export class TranscriptMerger {
 			finalText = completion.choices[0]?.message?.content?.trim() || "";
 			const timeMs = Date.now() - startTime;
 
-			logger.info(
+			logger.debug(
 				{
 					model: mergeModel,
 					timeMs,
@@ -139,6 +152,7 @@ export class TranscriptMerger {
 		} catch (error) {
 			logError("LLM merge failed, using fallback", error);
 			finalText = deepgramText || groqText;
+			mergeStrategy = "llm_fallback";
 		}
 
 		const distToGroq = levenshteinDistance(finalText, groqText);
@@ -160,6 +174,7 @@ export class TranscriptMerger {
 
 		return {
 			text: finalText,
+			strategy: mergeStrategy,
 			accuracy: {
 				sourcesMatch: false,
 				editDistance,


### PR DESCRIPTION
## Summary

- Add structured per-stage timing and metadata capture to `processAudio()` so latency is attributable by stage instead of a single coarse bucket
- Split the bloated success log (which dumped full transcript text) into a clean outcome log + a structured performance log (`type: "perf"`)
- Downgrade sub-module success logs to debug to reduce hot-path noise

## Changes

### `src/daemon/service.ts`
- `TranscriptionMetrics` interface with timing fields: `conversionMs`, `groqMs`, `deepgramMs`, `mergeMs`, `clipboardMs`, `statsWriteMs`, `historyAppendMs`, `notificationEnqueueMs`
- Metadata capture: `rawAudioBytes`, `recordingDurationMs`, `convertedAudioBytes`, `streamingEnabled`, `audioFormatStrategy`, `mergeStrategy`, `deepgramStopReason`
- `timeAsync()` helper to wrap async calls with duration measurement
- Two info logs per success: outcome (engine, text length, merge confidence) + perf record (all metrics, filterable via `type: "perf"`)

### `src/transcribe/deepgram-streaming.ts`
- `StreamingStopReason` type: `finalize_transcript | finalize_timeout | close_event | close_timeout | not_connected`
- `stop()` now returns `stopReason` in `StreamingResult`
- `close_timeout` explicitly preserved so tail-latency analysis can distinguish transport-close stalls from finalize stalls

### `src/transcribe/merger.ts`
- `MergeStrategy` type: `exact_match | single_source | llm | llm_fallback | empty`
- `strategy` field added to `MergeResult`

### Log noise reduction
- `converter.ts`, `groq.ts`, `merger.ts`, `clipboard.ts`, `notification.ts`: success logs downgraded from `info` to `debug`

## Validation

- `tsc --noEmit` — zero errors
- `vitest run` — 29 passed, 3 failed (pre-existing: withRetry log-permission flake, crash recovery ESRCH flake)
- No product behavior changes

## Example perf log output

```json
{
  "type": "perf",
  "totalMs": 1281,
  "conversionMs": 442,
  "groqMs": 380,
  "deepgramMs": 350,
  "mergeMs": 398,
  "clipboardMs": 12,
  "statsWriteMs": 5,
  "historyAppendMs": 8,
  "notificationEnqueueMs": 3,
  "rawAudioBytes": 1540000,
  "recordingDurationMs": 3200,
  "convertedAudioBytes": 181000,
  "streamingEnabled": true,
  "audioFormatStrategy": "opus",
  "mergeStrategy": "llm",
  "deepgramStopReason": "finalize_transcript",
  "engine": "groq+deepgram",
  "textLength": 42,
  "groqTextLength": 45,
  "deepgramTextLength": 40
}
```

## Follow-up (Milestone 2+)

- `audioFormatStrategy` is always `"opus"` — M3 will make it conditional
- Merger `strategy` covers current paths — M2 will add cheap gating strategies (`normalized_match`, `punctuation_only`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming transcription now reports explicit stop reasons.
  * Merge results now include the strategy used to combine sources.
  * Transcription workflows surface detailed performance metrics (per-stage timings, text-size tracking).

* **Improvements**
  * Reduced success-log verbosity for notifications, clipboard, conversion, and transcription steps.
  * Enhanced error handling, telemetry, and observability across transcription and post-processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->