### PR TITLE
Improve overlay phase transitions and success feedback

### DIFF
--- a/overlay/src/renderer/App.tsx
+++ b/overlay/src/renderer/App.tsx
@@ -177,13 +177,22 @@ export function App() {
 	const [waveformExiting, setWaveformExiting] = useState(false);
 	const indicatorTimeoutRef = useRef<number | null>(null);
 	const waveformTimeoutRef = useRef<number | null>(null);
+	const previousOverlayStateRef = useRef<OverlayState>(overlayState);
 	const transitionKeyRef = useRef(0);
 
-	const showWaveform = isRecording || waveformExiting;
+	const showWaveform =
+		isRecording ||
+		waveformExiting ||
+		(overlayState === "processing" &&
+			previousOverlayStateRef.current === "recording");
 
 	useEffect(() => {
 		window.electronAPI?.notifyReady();
 	}, []);
+
+	useEffect(() => {
+		previousOverlayStateRef.current = overlayState;
+	}, [overlayState]);
 
 	useEffect(() => {
 		if (nextIndicatorState === currentIndicator?.state) {

--- a/overlay/src/renderer/App.tsx
+++ b/overlay/src/renderer/App.tsx
@@ -51,6 +51,11 @@ function getStateStyles(state: OverlayState): {
 
 type IndicatorState = Exclude<OverlayState, "hidden" | "recording">;
 
+interface AnimatedIndicator {
+	state: IndicatorState;
+	key: number;
+}
+
 function StatusIndicator({ state }: { state: IndicatorState }) {
 	if (state === "connecting") {
 		return (
@@ -76,20 +81,19 @@ function StatusIndicator({ state }: { state: IndicatorState }) {
 	if (state === "success") {
 		return (
 			<div className="status-indicator success">
-				<svg
-					className="checkmark"
-					viewBox="0 0 24 24"
-					width="24"
-					height="24"
-					fill="none"
-					stroke="currentColor"
-					strokeWidth="3"
-					aria-label="Success"
-					role="img"
-				>
-					<title>Success</title>
-					<polyline points="20 6 9 17 4 12" />
-				</svg>
+				<span className="checkmark-badge" aria-label="Success" role="img">
+					<svg
+						className="checkmark-circle-icon"
+						viewBox="0 0 24 24"
+						width="30"
+						height="30"
+						fill="none"
+					>
+						<title>Success</title>
+						<circle cx="12" cy="12" r="9" />
+						<polyline points="8.5 12.5 11 15 15.5 9.5" />
+					</svg>
+				</span>
 			</div>
 		);
 	}
@@ -141,21 +145,27 @@ export function App() {
 
 	const isRecording = overlayState === "recording";
 	const isProcessing = overlayState === "processing";
-	const showWaveform = overlayState === "recording";
 	const nextIndicatorState = getIndicatorState(overlayState);
 	const [currentIndicator, setCurrentIndicator] =
-		useState<IndicatorState | null>(nextIndicatorState);
+		useState<AnimatedIndicator | null>(
+			nextIndicatorState ? { state: nextIndicatorState, key: 0 } : null,
+		);
 	const [leavingIndicator, setLeavingIndicator] =
-		useState<IndicatorState | null>(null);
+		useState<AnimatedIndicator | null>(null);
 	const [isAnimatingIndicator, setIsAnimatingIndicator] = useState(false);
+	const [waveformExiting, setWaveformExiting] = useState(false);
 	const indicatorTimeoutRef = useRef<number | null>(null);
+	const waveformTimeoutRef = useRef<number | null>(null);
+	const transitionKeyRef = useRef(0);
+
+	const showWaveform = isRecording || waveformExiting;
 
 	useEffect(() => {
 		window.electronAPI?.notifyReady();
 	}, []);
 
 	useEffect(() => {
-		if (nextIndicatorState === currentIndicator) {
+		if (nextIndicatorState === currentIndicator?.state) {
 			return;
 		}
 
@@ -171,21 +181,62 @@ export function App() {
 			return;
 		}
 
+		transitionKeyRef.current += 1;
+		const nextIndicator: AnimatedIndicator = {
+			state: nextIndicatorState,
+			key: transitionKeyRef.current,
+		};
+
 		setLeavingIndicator(currentIndicator);
-		setCurrentIndicator(nextIndicatorState);
+		setCurrentIndicator(nextIndicator);
 		setIsAnimatingIndicator(true);
 
 		indicatorTimeoutRef.current = window.setTimeout(() => {
 			setLeavingIndicator(null);
 			setIsAnimatingIndicator(false);
 			indicatorTimeoutRef.current = null;
-		}, 280);
+		}, 320);
 	}, [nextIndicatorState, currentIndicator]);
+
+	useEffect(() => {
+		if (overlayState === "recording") {
+			if (waveformTimeoutRef.current !== null) {
+				window.clearTimeout(waveformTimeoutRef.current);
+				waveformTimeoutRef.current = null;
+			}
+			setWaveformExiting(false);
+			return;
+		}
+
+		if (overlayState === "processing") {
+			setWaveformExiting(true);
+
+			if (waveformTimeoutRef.current !== null) {
+				window.clearTimeout(waveformTimeoutRef.current);
+			}
+
+			waveformTimeoutRef.current = window.setTimeout(() => {
+				setWaveformExiting(false);
+				waveformTimeoutRef.current = null;
+			}, 180);
+			return;
+		}
+
+		if (waveformTimeoutRef.current !== null) {
+			window.clearTimeout(waveformTimeoutRef.current);
+			waveformTimeoutRef.current = null;
+		}
+		setWaveformExiting(false);
+	}, [overlayState]);
 
 	useEffect(() => {
 		return () => {
 			if (indicatorTimeoutRef.current !== null) {
 				window.clearTimeout(indicatorTimeoutRef.current);
+			}
+
+			if (waveformTimeoutRef.current !== null) {
+				window.clearTimeout(waveformTimeoutRef.current);
 			}
 		};
 	}, []);
@@ -221,21 +272,30 @@ export function App() {
 					barRadius={1.5}
 					height={50}
 					fadeEdges={true}
-					style={{ width: "100%", height: "100%" }}
+					style={{
+						width: "100%",
+						height: "100%",
+						opacity: waveformExiting ? 0 : 1,
+						transition: "opacity 0.18s ease-out",
+					}}
 				/>
 			)}
 
 			<div className="status-stack" aria-hidden="true">
 				{leavingIndicator && isAnimatingIndicator && (
-					<div className="status-layer status-layer-leave">
-						<StatusIndicator state={leavingIndicator} />
+					<div
+						className="status-layer status-layer-leave"
+						key={`leave-${leavingIndicator.key}`}
+					>
+						<StatusIndicator state={leavingIndicator.state} />
 					</div>
 				)}
 				{currentIndicator && (
 					<div
 						className={`status-layer ${isAnimatingIndicator ? "status-layer-enter" : ""}`}
+						key={`current-${currentIndicator.key}`}
 					>
-						<StatusIndicator state={currentIndicator} />
+						<StatusIndicator state={currentIndicator.state} />
 					</div>
 				)}
 			</div>

--- a/overlay/src/renderer/App.tsx
+++ b/overlay/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LiveWaveform } from "./LiveWaveform";
 import { type OverlayState, useDaemonState } from "./useDaemonState";
 import "./styles.css";
@@ -49,7 +49,9 @@ function getStateStyles(state: OverlayState): {
 	}
 }
 
-function StatusIndicator({ state }: { state: OverlayState }) {
+type IndicatorState = Exclude<OverlayState, "hidden" | "recording">;
+
+function StatusIndicator({ state }: { state: IndicatorState }) {
 	if (state === "connecting") {
 		return (
 			<div className="status-indicator connecting">
@@ -114,7 +116,23 @@ function StatusIndicator({ state }: { state: OverlayState }) {
 		);
 	}
 
+	if (state === "processing") {
+		return (
+			<div className="status-indicator processing">
+				<span className="shimmering-text">Transcribing...</span>
+			</div>
+		);
+	}
+
 	return null;
+}
+
+function getIndicatorState(state: OverlayState): IndicatorState | null {
+	if (state === "hidden" || state === "recording") {
+		return null;
+	}
+
+	return state;
 }
 
 export function App() {
@@ -123,11 +141,53 @@ export function App() {
 
 	const isRecording = overlayState === "recording";
 	const isProcessing = overlayState === "processing";
-	const showWaveform =
-		overlayState === "recording" || overlayState === "processing";
+	const showWaveform = overlayState === "recording";
+	const nextIndicatorState = getIndicatorState(overlayState);
+	const [currentIndicator, setCurrentIndicator] =
+		useState<IndicatorState | null>(nextIndicatorState);
+	const [leavingIndicator, setLeavingIndicator] =
+		useState<IndicatorState | null>(null);
+	const [isAnimatingIndicator, setIsAnimatingIndicator] = useState(false);
+	const indicatorTimeoutRef = useRef<number | null>(null);
 
 	useEffect(() => {
 		window.electronAPI?.notifyReady();
+	}, []);
+
+	useEffect(() => {
+		if (nextIndicatorState === currentIndicator) {
+			return;
+		}
+
+		if (indicatorTimeoutRef.current !== null) {
+			window.clearTimeout(indicatorTimeoutRef.current);
+			indicatorTimeoutRef.current = null;
+		}
+
+		if (nextIndicatorState === null) {
+			setLeavingIndicator(null);
+			setCurrentIndicator(null);
+			setIsAnimatingIndicator(false);
+			return;
+		}
+
+		setLeavingIndicator(currentIndicator);
+		setCurrentIndicator(nextIndicatorState);
+		setIsAnimatingIndicator(true);
+
+		indicatorTimeoutRef.current = window.setTimeout(() => {
+			setLeavingIndicator(null);
+			setIsAnimatingIndicator(false);
+			indicatorTimeoutRef.current = null;
+		}, 280);
+	}, [nextIndicatorState, currentIndicator]);
+
+	useEffect(() => {
+		return () => {
+			if (indicatorTimeoutRef.current !== null) {
+				window.clearTimeout(indicatorTimeoutRef.current);
+			}
+		};
 	}, []);
 
 	if (overlayState === "hidden") {
@@ -165,7 +225,20 @@ export function App() {
 				/>
 			)}
 
-			<StatusIndicator state={overlayState} />
+			<div className="status-stack" aria-hidden="true">
+				{leavingIndicator && isAnimatingIndicator && (
+					<div className="status-layer status-layer-leave">
+						<StatusIndicator state={leavingIndicator} />
+					</div>
+				)}
+				{currentIndicator && (
+					<div
+						className={`status-layer ${isAnimatingIndicator ? "status-layer-enter" : ""}`}
+					>
+						<StatusIndicator state={currentIndicator} />
+					</div>
+				)}
+			</div>
 
 			{overlayState === "error" && errorMessage && (
 				<span className="error-message">{errorMessage}</span>

--- a/overlay/src/renderer/App.tsx
+++ b/overlay/src/renderer/App.tsx
@@ -139,6 +139,26 @@ function getIndicatorState(state: OverlayState): IndicatorState | null {
 	return state;
 }
 
+function getAriaStatusText(state: OverlayState, errorMessage?: string): string {
+	switch (state) {
+		case "connecting":
+			return "Connecting";
+		case "listening":
+			return "Listening";
+		case "recording":
+			return "Recording";
+		case "processing":
+			return "Transcribing";
+		case "success":
+			return "Transcription copied";
+		case "error":
+			return errorMessage ? `Error: ${errorMessage}` : "Error";
+		case "hidden":
+		default:
+			return "";
+	}
+}
+
 export function App() {
 	const { overlayState, errorMessage } = useDaemonState();
 	const styles = getStateStyles(overlayState);
@@ -146,6 +166,7 @@ export function App() {
 	const isRecording = overlayState === "recording";
 	const isProcessing = overlayState === "processing";
 	const nextIndicatorState = getIndicatorState(overlayState);
+	const ariaStatusText = getAriaStatusText(overlayState, errorMessage);
 	const [currentIndicator, setCurrentIndicator] =
 		useState<AnimatedIndicator | null>(
 			nextIndicatorState ? { state: nextIndicatorState, key: 0 } : null,
@@ -299,6 +320,10 @@ export function App() {
 					</div>
 				)}
 			</div>
+
+			<output className="sr-only" aria-live="polite" aria-atomic="true">
+				{ariaStatusText}
+			</output>
 
 			{overlayState === "error" && errorMessage && (
 				<span className="error-message">{errorMessage}</span>

--- a/overlay/src/renderer/styles.css
+++ b/overlay/src/renderer/styles.css
@@ -31,17 +31,21 @@
 }
 
 .status-layer-enter {
-	animation: status-slide-up-in 0.28s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+	animation: status-slide-up-in 0.32s cubic-bezier(0.16, 0.84, 0.24, 1) forwards;
 }
 
 .status-layer-leave {
-	animation: status-slide-up-out 0.28s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+	animation: status-slide-up-out 0.32s cubic-bezier(0.16, 0.84, 0.24, 1)
+		forwards;
 }
 
 @keyframes status-slide-up-in {
 	0% {
-		transform: translateY(18px);
+		transform: translateY(20px);
 		opacity: 0;
+	}
+	40% {
+		opacity: 0.85;
 	}
 	100% {
 		transform: translateY(0);
@@ -55,7 +59,7 @@
 		opacity: 1;
 	}
 	100% {
-		transform: translateY(-18px);
+		transform: translateY(-20px);
 		opacity: 0;
 	}
 }
@@ -143,17 +147,86 @@
 	color: #10b981;
 }
 
-.status-indicator.success .checkmark {
-	animation: checkmark-draw 0.4s ease-out forwards;
+.status-indicator.success .checkmark-badge {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 38px;
+	height: 38px;
+	border-radius: 50%;
+	background: radial-gradient(
+		circle at center,
+		rgba(16, 185, 129, 0.28) 0%,
+		rgba(16, 185, 129, 0.15) 60%,
+		rgba(16, 185, 129, 0.06) 100%
+	);
+	box-shadow:
+		0 0 0 1px rgba(16, 185, 129, 0.4) inset,
+		0 0 18px rgba(16, 185, 129, 0.28);
+	animation: success-pop 0.22s cubic-bezier(0.22, 0.9, 0.28, 1.12) forwards;
 }
 
-@keyframes checkmark-draw {
+.status-indicator.success .checkmark-badge::after {
+	content: "";
+	position: absolute;
+	inset: 2px;
+	border-radius: 50%;
+	border: 1.5px solid rgba(16, 185, 129, 0.55);
+	animation: success-ring 0.42s ease-out forwards;
+}
+
+.status-indicator.success .checkmark-circle-icon {
+	position: relative;
+	color: #10b981;
+	filter: drop-shadow(0 0 6px rgba(16, 185, 129, 0.45));
+}
+
+.status-indicator.success .checkmark-circle-icon circle,
+.status-indicator.success .checkmark-circle-icon polyline {
+	stroke: currentColor;
+	stroke-width: 2.2;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+.status-indicator.success .checkmark-circle-icon polyline {
+	stroke-dasharray: 18;
+	stroke-dashoffset: 18;
+	animation: checkmark-stroke 0.18s 0.05s ease-out forwards;
+}
+
+@keyframes success-pop {
 	0% {
-		stroke-dasharray: 30;
-		stroke-dashoffset: 30;
+		transform: scale(0.9);
+		opacity: 0;
+	}
+	65% {
+		transform: scale(1.04);
+		opacity: 1;
 	}
 	100% {
-		stroke-dasharray: 30;
+		transform: scale(1);
+		opacity: 1;
+	}
+}
+
+@keyframes success-ring {
+	0% {
+		transform: scale(0.84);
+		opacity: 0.7;
+	}
+	100% {
+		transform: scale(1.2);
+		opacity: 0;
+	}
+}
+
+@keyframes checkmark-stroke {
+	0% {
+		stroke-dashoffset: 18;
+	}
+	100% {
 		stroke-dashoffset: 0;
 	}
 }

--- a/overlay/src/renderer/styles.css
+++ b/overlay/src/renderer/styles.css
@@ -70,10 +70,6 @@
 	font-weight: 500;
 }
 
-.status-indicator.processing {
-	/* Uses base centering from .status-indicator */
-}
-
 .shimmering-text {
 	font-size: 16px;
 	font-weight: 600;
@@ -184,7 +180,7 @@
 
 .status-indicator.success .checkmark-circle-icon circle,
 .status-indicator.success .checkmark-circle-icon polyline {
-	stroke: currentColor;
+	stroke: currentcolor;
 	stroke-width: 2.2;
 	stroke-linecap: round;
 	stroke-linejoin: round;
@@ -293,4 +289,16 @@
 
 .state-error {
 	border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 }

--- a/overlay/src/renderer/styles.css
+++ b/overlay/src/renderer/styles.css
@@ -7,6 +7,9 @@
 /* Status indicators */
 .status-indicator {
 	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -14,10 +17,86 @@
 	pointer-events: none;
 }
 
+.status-stack {
+	position: absolute;
+	inset: 0;
+	overflow: hidden;
+	pointer-events: none;
+}
+
+.status-layer {
+	position: absolute;
+	inset: 0;
+	will-change: transform, opacity;
+}
+
+.status-layer-enter {
+	animation: status-slide-up-in 0.28s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.status-layer-leave {
+	animation: status-slide-up-out 0.28s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+@keyframes status-slide-up-in {
+	0% {
+		transform: translateY(18px);
+		opacity: 0;
+	}
+	100% {
+		transform: translateY(0);
+		opacity: 1;
+	}
+}
+
+@keyframes status-slide-up-out {
+	0% {
+		transform: translateY(0);
+		opacity: 1;
+	}
+	100% {
+		transform: translateY(-18px);
+		opacity: 0;
+	}
+}
+
 .status-text {
 	color: rgba(255, 255, 255, 0.7);
 	font-size: 14px;
 	font-weight: 500;
+}
+
+.status-indicator.processing {
+	/* Uses base centering from .status-indicator */
+}
+
+.shimmering-text {
+	font-size: 16px;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	background-image: linear-gradient(
+		110deg,
+		rgba(255, 255, 255, 0.25) 0%,
+		rgba(255, 255, 255, 0.95) 30%,
+		rgba(255, 255, 255, 0.25) 60%
+	);
+	background-size: 220% 100%;
+	background-position: 180% 0;
+	background-clip: text;
+	-webkit-background-clip: text;
+	color: transparent;
+	-webkit-text-fill-color: transparent;
+	animation: shimmer-slide 1.6s linear infinite;
+	text-shadow: 0 0 8px rgba(255, 255, 255, 0.18);
+}
+
+@keyframes shimmer-slide {
+	0% {
+		background-position: 180% 0;
+	}
+	100% {
+		background-position: -40% 0;
+	}
 }
 
 /* Connecting state - pulsing dots */

--- a/overlay/src/renderer/styles.css
+++ b/overlay/src/renderer/styles.css
@@ -298,7 +298,7 @@
 	padding: 0;
 	margin: -1px;
 	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
+	clip-path: inset(50%);
 	white-space: nowrap;
 	border: 0;
 }


### PR DESCRIPTION
## Summary
- smooth status handoffs between recording, processing, and success with keyed enter/leave transitions so animations consistently run
- add a short waveform fade bridge from recording to processing to remove abrupt state swaps
- refine success feedback with an animated check-in-circle treatment (pop, ring pulse, and subtle glow) while keeping the UI text-free

## Validation
- bun run build (overlay)
- manual service restart and live overlay check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Transcribing..." processing indicator, two-layer enter/leave indicator transitions, and live ARIA status output (includes error text)

* **Visual Improvements**
  * Redesigned success badge with new animations and shimmer text; status indicator centered with slide/fade transitions

* **Bug Fixes**
  * Improved waveform exit animation and timeout-based cleanup to avoid stuck or lingering states
<!-- end of auto-generated comment: release notes by coderabbit.ai -->