### PR TITLE
test: add transcript quality fixtures

### DIFF
--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -30,11 +30,8 @@ import {
 	type MergeStrategy,
 	TranscriptMerger,
 } from "../transcribe/merger";
-import {
-	type TranscriptQualityReason,
-	type TranscriptQualityResult,
-	validateTranscript,
-} from "../transcribe/quality";
+import type { TranscriptQualityReason } from "../transcribe/quality";
+import { recoverTranscriptQuality } from "../transcribe/recovery";
 import { ErrorTemplates, formatUserError } from "../utils/error-templates";
 import { errorIncludes, getErrorCode } from "../utils/errors";
 import { appendHistory } from "../utils/history";
@@ -1274,75 +1271,52 @@ export class DaemonService {
 			}
 
 			// --- Validation + recovery ---
-			let validation: TranscriptQualityResult = validateTranscript(finalText);
-			metrics.validationReasons = validation.reasons;
-			metrics.trimmedHallucinationSuffix = validation.trimmedSuffix;
-			finalText = validation.text;
+			const recovery = await recoverTranscriptQuality({
+				finalText,
+				groqText,
+				deepgramText,
+				mergeStrategy: metrics.mergeStrategy,
+				mergeReason: metrics.mergeReason,
+				accuracy,
+				repairMerge: async (groq, deepgram, failed, reasons) => {
+					const repairTimed = await timeAsync(() =>
+						this.merger.repairMerge(groq, deepgram, failed, reasons),
+					);
+					metrics.mergeMs += repairTimed.durationMs;
+					return repairTimed.result;
+				},
+			});
 
-			if (!validation.valid && groqText && deepgramText) {
+			if (recovery.repairAttempted) {
 				logger.warn(
 					{
-						reasons: validation.reasons,
+						reasons: recovery.initialValidation.reasons,
 						text: finalText.substring(0, 200),
 					},
 					"Merged transcript failed validation; retrying repair",
 				);
-
-				metrics.validationRetryCount = 1;
-				try {
-					const repairTimed = await timeAsync(() =>
-						this.merger.repairMerge(
-							groqText,
-							deepgramText,
-							finalText,
-							validation.reasons,
-						),
-					);
-					metrics.mergeMs += repairTimed.durationMs;
-					finalText = repairTimed.result.text;
-					accuracy = repairTimed.result.accuracy;
-					metrics.mergeStrategy = repairTimed.result.strategy;
-					metrics.mergeReason = repairTimed.result.reason;
-					validation = validateTranscript(finalText);
-					metrics.validationReasons = validation.reasons;
-					metrics.trimmedHallucinationSuffix = validation.trimmedSuffix;
-					finalText = validation.text;
-				} catch (error) {
-					logger.warn(
-						{ err: error, reasons: validation.reasons },
-						"Merged transcript repair failed; trying source fallback",
-					);
-				}
 			}
 
-			if (!validation.valid) {
-				const deepgramValidation = deepgramText
-					? validateTranscript(deepgramText)
-					: null;
-				const groqValidation = groqText ? validateTranscript(groqText) : null;
-
-				if (deepgramValidation?.valid && deepgramValidation.text) {
-					finalText = deepgramValidation.text;
-					validation = deepgramValidation;
-					metrics.validationFallbackSource = "deepgram";
-					metrics.mergeStrategy = "single_source";
-					metrics.mergeReason = "deepgram_only";
-				} else if (groqValidation?.valid && groqValidation.text) {
-					finalText = groqValidation.text;
-					validation = groqValidation;
-					metrics.validationFallbackSource = "groq";
-					metrics.mergeStrategy = "single_source";
-					metrics.mergeReason = "groq_only";
-				}
-
-				metrics.validationReasons = validation.reasons;
-				metrics.trimmedHallucinationSuffix = validation.trimmedSuffix;
+			if (recovery.repairFailed) {
+				logger.warn(
+					{ reasons: recovery.validation.reasons },
+					"Merged transcript repair failed; trying source fallback",
+				);
 			}
 
-			if (!validation.valid) {
+			finalText = recovery.finalText;
+			accuracy = recovery.accuracy;
+			metrics.mergeStrategy = recovery.mergeStrategy;
+			metrics.mergeReason = recovery.mergeReason;
+			metrics.validationReasons = recovery.validation.reasons;
+			metrics.validationRetryCount = recovery.validationRetryCount;
+			metrics.validationFallbackSource = recovery.validationFallbackSource;
+			metrics.trimmedHallucinationSuffix = recovery.validation.trimmedSuffix;
+
+			if (!recovery.validation.valid) {
 				logger.error(
 					{
-						reasons: validation.reasons,
+						reasons: recovery.validation.reasons,
 						text: finalText.substring(0, 200),
 						textLength: finalText.length,
 						duration,
@@ -1355,7 +1329,7 @@ export class DaemonService {
 					"error",
 				);
 				throw new Error(
-					`Transcript validation failed: ${validation.reasons.join(", ")}`,
+					`Transcript validation failed: ${recovery.validation.reasons.join(", ")}`,
 				);
 			}
 

--- a/src/transcribe/quality.ts
+++ b/src/transcribe/quality.ts
@@ -22,7 +22,7 @@ const PROMPT_ARTIFACT_PATTERNS = [
 	/format\s+as\s+a\s+headed\s+numbered\s+list/i,
 	/merge\s+the\s+two\s+transcripts/i,
 	/output\s+only\s+the\s+final\s+transcript/i,
-	/transcript\s+1\b.*\btranscript\s+2\b/i,
+	/transcript\s+1\b[\s\S]*\btranscript\s+2\b/i,
 ];
 
 const DETACHABLE_SUFFIX_PATTERNS = [

--- a/src/transcribe/quality.ts
+++ b/src/transcribe/quality.ts
@@ -22,6 +22,7 @@ const PROMPT_ARTIFACT_PATTERNS = [
 	/format\s+as\s+a\s+headed\s+numbered\s+list/i,
 	/merge\s+the\s+two\s+transcripts/i,
 	/output\s+only\s+the\s+final\s+transcript/i,
+	/transcript\s+1\b.*\btranscript\s+2\b/i,
 ];
 
 const DETACHABLE_SUFFIX_PATTERNS = [

--- a/src/transcribe/recovery.ts
+++ b/src/transcribe/recovery.ts
@@ -1,0 +1,111 @@
+import type { MergeReason, MergeResult, MergeStrategy } from "./merger";
+import {
+	type TranscriptQualityReason,
+	type TranscriptQualityResult,
+	validateTranscript,
+} from "./quality";
+
+export interface TranscriptRecoveryInput {
+	finalText: string;
+	groqText: string;
+	deepgramText: string;
+	mergeStrategy: MergeStrategy | "skip_no_speech" | "skip_hallucination";
+	mergeReason: MergeReason | null;
+	accuracy?: MergeResult["accuracy"];
+	repairMerge?: (
+		groqText: string,
+		deepgramText: string,
+		failedText: string,
+		reasons: TranscriptQualityReason[],
+	) => Promise<MergeResult>;
+}
+
+export interface TranscriptRecoveryResult {
+	finalText: string;
+	initialValidation: TranscriptQualityResult;
+	validation: TranscriptQualityResult;
+	mergeStrategy: MergeStrategy | "skip_no_speech" | "skip_hallucination";
+	mergeReason: MergeReason | null;
+	accuracy?: MergeResult["accuracy"];
+	validationRetryCount: number;
+	validationFallbackSource: "none" | "groq" | "deepgram";
+	repairAttempted: boolean;
+	repairFailed: boolean;
+}
+
+export async function recoverTranscriptQuality({
+	finalText,
+	groqText,
+	deepgramText,
+	mergeStrategy,
+	mergeReason,
+	accuracy,
+	repairMerge,
+}: TranscriptRecoveryInput): Promise<TranscriptRecoveryResult> {
+	let validation = validateTranscript(finalText);
+	const initialValidation = validation;
+	let recoveredText = validation.text;
+	let recoveredStrategy = mergeStrategy;
+	let recoveredReason = mergeReason;
+	let recoveredAccuracy = accuracy;
+	let validationRetryCount = 0;
+	let validationFallbackSource: "none" | "groq" | "deepgram" = "none";
+	let repairAttempted = false;
+	let repairFailed = false;
+
+	if (!validation.valid && groqText && deepgramText && repairMerge) {
+		repairAttempted = true;
+		validationRetryCount = 1;
+
+		try {
+			const repair = await repairMerge(
+				groqText,
+				deepgramText,
+				recoveredText,
+				validation.reasons,
+			);
+			recoveredText = repair.text;
+			recoveredAccuracy = repair.accuracy;
+			recoveredStrategy = repair.strategy;
+			recoveredReason = repair.reason;
+			validation = validateTranscript(recoveredText);
+			recoveredText = validation.text;
+		} catch {
+			repairFailed = true;
+		}
+	}
+
+	if (!validation.valid) {
+		const deepgramValidation = deepgramText
+			? validateTranscript(deepgramText)
+			: null;
+		const groqValidation = groqText ? validateTranscript(groqText) : null;
+
+		if (deepgramValidation?.valid && deepgramValidation.text) {
+			recoveredText = deepgramValidation.text;
+			validation = deepgramValidation;
+			validationFallbackSource = "deepgram";
+			recoveredStrategy = "single_source";
+			recoveredReason = "deepgram_only";
+		} else if (groqValidation?.valid && groqValidation.text) {
+			recoveredText = groqValidation.text;
+			validation = groqValidation;
+			validationFallbackSource = "groq";
+			recoveredStrategy = "single_source";
+			recoveredReason = "groq_only";
+		}
+	}
+
+	return {
+		finalText: recoveredText,
+		initialValidation,
+		validation,
+		mergeStrategy: recoveredStrategy,
+		mergeReason: recoveredReason,
+		accuracy: recoveredAccuracy,
+		validationRetryCount,
+		validationFallbackSource,
+		repairAttempted,
+		repairFailed,
+	};
+}

--- a/src/transcribe/recovery.ts
+++ b/src/transcribe/recovery.ts
@@ -87,12 +87,14 @@ export async function recoverTranscriptQuality({
 			validationFallbackSource = "deepgram";
 			recoveredStrategy = "single_source";
 			recoveredReason = "deepgram_only";
+			recoveredAccuracy = undefined;
 		} else if (groqValidation?.valid && groqValidation.text) {
 			recoveredText = groqValidation.text;
 			validation = groqValidation;
 			validationFallbackSource = "groq";
 			recoveredStrategy = "single_source";
 			recoveredReason = "groq_only";
+			recoveredAccuracy = undefined;
 		}
 	}
 

--- a/tests/fixtures/transcript-quality.ts
+++ b/tests/fixtures/transcript-quality.ts
@@ -44,6 +44,12 @@ export const promptArtifactFixtures: QualityFixture[] = [
 		expectedValid: false,
 		expectedReasons: ["prompt_artifact"],
 	},
+	{
+		name: "multiline transcript labels leaked",
+		input: "Transcript 1:\nUse AGENTS.md.\n\nTranscript 2:\nUse agents dot MD.",
+		expectedValid: false,
+		expectedReasons: ["prompt_artifact"],
+	},
 ];
 
 export const promptArtifactFalsePositiveFixtures: QualityFixture[] = [

--- a/tests/fixtures/transcript-quality.ts
+++ b/tests/fixtures/transcript-quality.ts
@@ -1,0 +1,135 @@
+import type { TranscriptQualityReason } from "../../src/transcribe/quality";
+
+export interface QualityFixture {
+	name: string;
+	input: string;
+	expectedValid: boolean;
+	expectedReasons: TranscriptQualityReason[];
+	expectedText?: string;
+}
+
+export const promptArtifactFixtures: QualityFixture[] = [
+	{
+		name: "preserve terms order",
+		input:
+			"We need to update the merge prompt. Preserve the following terms in the following order.",
+		expectedValid: false,
+		expectedReasons: ["prompt_artifact"],
+	},
+	{
+		name: "preserve commands app",
+		input:
+			"The CLI should expose status and health checks. Preserve the following commands for the app.",
+		expectedValid: false,
+		expectedReasons: ["prompt_artifact"],
+	},
+	{
+		name: "preserve commands format",
+		input:
+			"Let's clean the docs and examples. Preserve the following commands in a good format.",
+		expectedValid: false,
+		expectedReasons: ["prompt_artifact"],
+	},
+	{
+		name: "merge instruction leaked",
+		input:
+			"Use the Deepgram version for the first sentence. Merge the two transcripts.",
+		expectedValid: false,
+		expectedReasons: ["prompt_artifact"],
+	},
+	{
+		name: "transcript labels leaked",
+		input:
+			"Transcript 1 has the right file name. Transcript 2 has the right command.",
+		expectedValid: false,
+		expectedReasons: ["prompt_artifact"],
+	},
+];
+
+export const promptArtifactFalsePositiveFixtures: QualityFixture[] = [
+	{
+		name: "ordinary preserve request",
+		input:
+			"We should preserve the user's original wording as much as possible.",
+		expectedValid: true,
+		expectedReasons: [],
+	},
+	{
+		name: "literal transcript discussion",
+		input: "Add a section explaining how transcript history is stored locally.",
+		expectedValid: true,
+		expectedReasons: [],
+	},
+];
+
+export const suffixFixtures: QualityFixture[] = [
+	{
+		name: "thank you for watching suffix",
+		input: "We should improve the navigation bar. Thank you for watching.",
+		expectedValid: true,
+		expectedReasons: ["hallucination_suffix"],
+		expectedText: "We should improve the navigation bar.",
+	},
+	{
+		name: "thanks for watching suffix",
+		input:
+			"The daemon should keep recording state consistent. Thanks for watching.",
+		expectedValid: true,
+		expectedReasons: ["hallucination_suffix"],
+		expectedText: "The daemon should keep recording state consistent.",
+	},
+	{
+		name: "link in description suffix",
+		input:
+			"Let's test the crash recovery flow. If you want to know more about the software development process, please visit the link in the description.",
+		expectedValid: true,
+		expectedReasons: ["hallucination_suffix"],
+		expectedText: "Let's test the crash recovery flow.",
+	},
+	{
+		name: "subscribe suffix",
+		input: "Update the health command output. Please subscribe.",
+		expectedValid: true,
+		expectedReasons: ["hallucination_suffix"],
+		expectedText: "Update the health command output.",
+	},
+];
+
+export const mixedScriptFixtures: QualityFixture[] = [
+	{
+		name: "hangul fragment",
+		input: "The response format should remain the same 녹 complaint and edit.",
+		expectedValid: false,
+		expectedReasons: ["mixed_script"],
+	},
+	{
+		name: "arabic fragment",
+		input: "Keep the admin console wording but remove the مشكله fragment.",
+		expectedValid: false,
+		expectedReasons: ["mixed_script"],
+	},
+	{
+		name: "thai fragment",
+		input: "The fallback path should not include random สวัสดี characters.",
+		expectedValid: false,
+		expectedReasons: ["mixed_script"],
+	},
+];
+
+export const exactTokenFixtures = [
+	{
+		name: "filename split",
+		groqText: "Open AGENTS.md and update the workflow notes.",
+		deepgramText: "Open agents dot MD and update the workflow notes.",
+	},
+	{
+		name: "acronym corruption",
+		groqText: "The API should expose CRUD operations over SSE.",
+		deepgramText: "The API should expose cred operations over essay.",
+	},
+	{
+		name: "tool name corruption",
+		groqText: "Ask CodeRabbit to recheck the pull request.",
+		deepgramText: "Ask code rabbit to recheck the pull request.",
+	},
+];

--- a/tests/merger.test.ts
+++ b/tests/merger.test.ts
@@ -8,6 +8,7 @@ import {
 	type MergeReason,
 	type MergeStrategy,
 } from "../src/transcribe/merger";
+import { exactTokenFixtures } from "./fixtures/transcript-quality";
 
 describe("decideMerge", () => {
 	describe("exact match", () => {
@@ -128,6 +129,21 @@ describe("decideMerge", () => {
 			expect(result.strategy).toBe("minor_diff");
 			expect(result.reason).toBe("diff_below_threshold");
 			expect(result.text).toBe("update config path");
+		});
+	});
+
+	describe("exact token preservation routing", () => {
+		it.each(
+			exactTokenFixtures,
+		)("routes exact-token disagreement to LLM: $name", ({
+			groqText,
+			deepgramText,
+		}) => {
+			const result = decideMerge(groqText, deepgramText);
+
+			expect(result.strategy).toBe("llm");
+			expect(result.reason).toBe("diff_above_threshold");
+			expect(result.text).toBeUndefined();
 		});
 	});
 

--- a/tests/transcript-quality.test.ts
+++ b/tests/transcript-quality.test.ts
@@ -3,6 +3,12 @@ import {
 	trimHallucinationSuffix,
 	validateTranscript,
 } from "../src/transcribe/quality";
+import {
+	mixedScriptFixtures,
+	promptArtifactFalsePositiveFixtures,
+	promptArtifactFixtures,
+	suffixFixtures,
+} from "./fixtures/transcript-quality";
 
 describe("transcript quality validation", () => {
 	it("detects preserve-the-following instruction artifacts", () => {
@@ -14,12 +20,36 @@ describe("transcript quality validation", () => {
 		expect(result.reasons).toContain("prompt_artifact");
 	});
 
+	it.each(promptArtifactFixtures)("detects prompt artifact fixture: $name", ({
+		input,
+		expectedReasons,
+	}) => {
+		const result = validateTranscript(input);
+
+		expect(result.valid).toBe(false);
+		for (const reason of expectedReasons) {
+			expect(result.reasons).toContain(reason);
+		}
+	});
+
 	it("does not reject ordinary use of preserve", () => {
 		const result = validateTranscript(
 			"We should preserve the user's original wording as much as possible.",
 		);
 
 		expect(result.valid).toBe(true);
+	});
+
+	it.each(
+		promptArtifactFalsePositiveFixtures,
+	)("allows prompt-artifact false-positive fixture: $name", ({
+		input,
+		expectedReasons,
+	}) => {
+		const result = validateTranscript(input);
+
+		expect(result.valid).toBe(true);
+		expect(result.reasons).toEqual(expectedReasons);
 	});
 
 	it("trims detachable YouTube-style suffixes", () => {
@@ -29,6 +59,21 @@ describe("transcript quality validation", () => {
 
 		expect(result.trimmed).toBe(true);
 		expect(result.text).toBe("We should improve the navigation bar.");
+	});
+
+	it.each(suffixFixtures)("trims suffix fixture: $name", ({
+		input,
+		expectedText,
+		expectedReasons,
+	}) => {
+		const result = validateTranscript(input);
+
+		expect(result.valid).toBe(true);
+		expect(result.trimmedSuffix).toBe(true);
+		expect(result.text).toBe(expectedText);
+		for (const reason of expectedReasons) {
+			expect(result.reasons).toContain(reason);
+		}
 	});
 
 	it("treats suffix trimming as recoverable", () => {
@@ -49,5 +94,17 @@ describe("transcript quality validation", () => {
 
 		expect(result.valid).toBe(false);
 		expect(result.reasons).toContain("mixed_script");
+	});
+
+	it.each(mixedScriptFixtures)("detects mixed-script fixture: $name", ({
+		input,
+		expectedReasons,
+	}) => {
+		const result = validateTranscript(input);
+
+		expect(result.valid).toBe(false);
+		for (const reason of expectedReasons) {
+			expect(result.reasons).toContain(reason);
+		}
 	});
 });

--- a/tests/transcript-recovery.test.ts
+++ b/tests/transcript-recovery.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { MergeResult } from "../src/transcribe/merger";
+import { recoverTranscriptQuality } from "../src/transcribe/recovery";
+
+const accuracy: MergeResult["accuracy"] = {
+	sourcesMatch: false,
+	editDistance: 20,
+	confidence: 0.8,
+};
+
+function repairResult(text: string): MergeResult {
+	return {
+		text,
+		strategy: "llm_retry_cleaned",
+		reason: "llm_retry_succeeded",
+		accuracy,
+	};
+}
+
+describe("recoverTranscriptQuality", () => {
+	it("accepts valid merged text without retry or fallback", async () => {
+		const result = await recoverTranscriptQuality({
+			finalText: "Update the config loader tests.",
+			groqText: "Update the config loader tests.",
+			deepgramText: "Update the config loader tests.",
+			mergeStrategy: "llm",
+			mergeReason: "llm_succeeded",
+			accuracy,
+		});
+
+		expect(result.finalText).toBe("Update the config loader tests.");
+		expect(result.validation.valid).toBe(true);
+		expect(result.validationRetryCount).toBe(0);
+		expect(result.validationFallbackSource).toBe("none");
+		expect(result.repairAttempted).toBe(false);
+	});
+
+	it("uses successful repair when merged output fails validation", async () => {
+		const result = await recoverTranscriptQuality({
+			finalText:
+				"Update the daemon service. Preserve the following terms in the following order.",
+			groqText: "Update the daemon service.",
+			deepgramText: "Update the daemon service.",
+			mergeStrategy: "llm",
+			mergeReason: "llm_succeeded",
+			accuracy,
+			repairMerge: async () => repairResult("Update the daemon service."),
+		});
+
+		expect(result.finalText).toBe("Update the daemon service.");
+		expect(result.initialValidation.reasons).toContain("prompt_artifact");
+		expect(result.validation.valid).toBe(true);
+		expect(result.validationRetryCount).toBe(1);
+		expect(result.validationFallbackSource).toBe("none");
+		expect(result.mergeStrategy).toBe("llm_retry_cleaned");
+		expect(result.mergeReason).toBe("llm_retry_succeeded");
+	});
+
+	it("falls back to clean Deepgram source when repair fails", async () => {
+		const result = await recoverTranscriptQuality({
+			finalText: "Transcript 1 is better. Transcript 2 is worse.",
+			groqText: "Preserve the following commands for the app.",
+			deepgramText: "Run the focused quality tests.",
+			mergeStrategy: "llm",
+			mergeReason: "llm_succeeded",
+			repairMerge: async () => {
+				throw new Error("repair failed");
+			},
+		});
+
+		expect(result.finalText).toBe("Run the focused quality tests.");
+		expect(result.repairAttempted).toBe(true);
+		expect(result.repairFailed).toBe(true);
+		expect(result.validation.valid).toBe(true);
+		expect(result.validationFallbackSource).toBe("deepgram");
+		expect(result.mergeStrategy).toBe("single_source");
+		expect(result.mergeReason).toBe("deepgram_only");
+	});
+
+	it("falls back to Groq when Deepgram source is invalid", async () => {
+		const result = await recoverTranscriptQuality({
+			finalText: "Transcript 1 is better. Transcript 2 is worse.",
+			groqText: "Run the focused quality tests.",
+			deepgramText: "Preserve the following commands for the app.",
+			mergeStrategy: "llm",
+			mergeReason: "llm_succeeded",
+			repairMerge: async () => repairResult("Merge the two transcripts."),
+		});
+
+		expect(result.finalText).toBe("Run the focused quality tests.");
+		expect(result.repairAttempted).toBe(true);
+		expect(result.repairFailed).toBe(false);
+		expect(result.validation.valid).toBe(true);
+		expect(result.validationFallbackSource).toBe("groq");
+		expect(result.mergeStrategy).toBe("single_source");
+		expect(result.mergeReason).toBe("groq_only");
+	});
+
+	it("keeps failure when merge, repair, and sources are invalid", async () => {
+		const result = await recoverTranscriptQuality({
+			finalText: "Transcript 1 is better. Transcript 2 is worse.",
+			groqText: "Preserve the following commands for the app.",
+			deepgramText: "Merge the two transcripts.",
+			mergeStrategy: "llm",
+			mergeReason: "llm_succeeded",
+			repairMerge: async () =>
+				repairResult("Output only the final transcript."),
+		});
+
+		expect(result.validation.valid).toBe(false);
+		expect(result.validation.reasons).toContain("prompt_artifact");
+		expect(result.validationFallbackSource).toBe("none");
+	});
+});

--- a/tests/transcript-recovery.test.ts
+++ b/tests/transcript-recovery.test.ts
@@ -75,6 +75,7 @@ describe("recoverTranscriptQuality", () => {
 		expect(result.validationFallbackSource).toBe("deepgram");
 		expect(result.mergeStrategy).toBe("single_source");
 		expect(result.mergeReason).toBe("deepgram_only");
+		expect(result.accuracy).toBeUndefined();
 	});
 
 	it("falls back to Groq when Deepgram source is invalid", async () => {
@@ -94,6 +95,7 @@ describe("recoverTranscriptQuality", () => {
 		expect(result.validationFallbackSource).toBe("groq");
 		expect(result.mergeStrategy).toBe("single_source");
 		expect(result.mergeReason).toBe("groq_only");
+		expect(result.accuracy).toBeUndefined();
 	});
 
 	it("keeps failure when merge, repair, and sources are invalid", async () => {


### PR DESCRIPTION
## Summary
- Add redacted transcript quality fixtures for prompt artifacts, suffix trimming, mixed-script cases, and exact-token routing.
- Extract transcript validation recovery into a small helper and cover repair/fallback/failure paths.
- Add detection coverage for leaked Transcript 1 / Transcript 2 prompt artifacts.

## Verification
- bun test tests/transcript-quality.test.ts tests/transcript-recovery.test.ts tests/merger.test.ts
- bunx tsc --noEmit
- bunx biome check src/daemon/service.ts src/transcribe/quality.ts src/transcribe/recovery.ts tests/merger.test.ts tests/transcript-quality.test.ts tests/transcript-recovery.test.ts tests/fixtures/transcript-quality.ts
- bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic transcript recovery mechanism when validation fails, with intelligent fallback to alternative sources
  * Improved detection of transcription artifacts for enhanced accuracy

* **Tests**
  * Expanded test coverage for transcript quality validation using comprehensive fixture sets
  * Added recovery scenario testing with multiple fallback cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snehit70/hyprvox/pull/34)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->