### PR TITLE
fix: cap provider boost hints

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -196,7 +196,7 @@ The `streaming` option controls whether transcription happens in real-time durin
 
 #### Boost Words (Custom Vocabulary)
 
-The `boostWords` array is used to improve the detection of specific terms like names, acronyms, or technical jargon. Hyprvox also builds a computed project lexicon from boost words, common technical terms, and local repo filenames. That lexicon is passed to Groq, optionally to Deepgram keyterms, and to the merge prompt.
+The `boostWords` array is used to improve the detection of specific terms like names, acronyms, or technical jargon. Hyprvox also builds a computed project lexicon from boost words, common technical terms, and local repo filenames. Provider transcription hints preserve configured boost words and add lexicon terms; the merge prompt receives a smaller capped lexicon plus exact tokens found in the source transcripts.
 
 **Format and Limits:**
 - **Data Type**: Array of strings. Each entry can be a single word or a phrase.

--- a/docs/STT_FLOW.md
+++ b/docs/STT_FLOW.md
@@ -68,7 +68,7 @@ sequenceDiagram
 ### 4. Parallel Transcription
 To minimize latency and maximize accuracy, `hyprvox` executes requests to two separate providers simultaneously using `Promise.all`:
 
-Before provider calls, the daemon builds a local project lexicon from configured boost words, common technical terms, and repo filenames. This improves exact tokens such as `AGENTS.md`, `CRUD`, `SSE`, and `CodeRabbit`.
+Before provider calls, the daemon builds technical-term hints from configured boost words, common technical terms, and repo filenames. Configured boost words are preserved for provider hints, while a smaller computed project lexicon is cached for merge-context hints. This improves exact tokens such as `AGENTS.md`, `CRUD`, `SSE`, and `CodeRabbit`.
 
 1.  **Groq (Whisper Large V3)**:
     - **Strength**: Unrivaled technical accuracy and word recognition.
@@ -79,7 +79,7 @@ Before provider calls, the daemon builds a local project lexicon from configured
 
 **Fallback Logic**: If one service fails, the daemon automatically uses the result from the successful one. If both fail, a critical error notification is shown.
 
-**Technical Term Preservation**: Groq always receives the computed lexicon as prompt terms. Deepgram receives it as `keyterm` hints when `transcription.deepgramBoosting` is enabled.
+**Technical Term Preservation**: Groq always receives provider boost terms as prompt hints. Deepgram receives those terms as `keyterm` hints when `transcription.deepgramBoosting` is enabled. The merge prompt receives the capped project lexicon plus exact tokens found in either source transcript.
 
 **Replay Logging**: The daemon also logs the raw Groq source transcript at info level so merge-quality experiments can replay exact source pairs later.
 

--- a/src/transcribe/deepgram-boost.ts
+++ b/src/transcribe/deepgram-boost.ts
@@ -1,4 +1,6 @@
 const MAX_DEEPGRAM_KEYTERMS = 100;
+const MAX_DEEPGRAM_KEYTERM_TOKENS = 500;
+const MAX_DEEPGRAM_KEYTERM_QUERY_CHARS = 1200;
 
 function normalizeBoostWord(word: string): string {
 	return word.trim().replace(/\s+/g, " ");
@@ -7,6 +9,8 @@ function normalizeBoostWord(word: string): string {
 export function sanitizeDeepgramKeyterms(boostWords: string[]): string[] {
 	const seen = new Set<string>();
 	const keyterms: string[] = [];
+	let tokenCount = 0;
+	let queryChars = 0;
 
 	for (const rawWord of boostWords) {
 		const word = normalizeBoostWord(rawWord);
@@ -15,8 +19,21 @@ export function sanitizeDeepgramKeyterms(boostWords: string[]): string[] {
 		const dedupeKey = word.toLowerCase();
 		if (seen.has(dedupeKey)) continue;
 
+		const wordTokenCount = word.split(/\s+/).length;
+		const wordQueryChars = `keyterm=${encodeURIComponent(word)}`.length;
+		const separatorChars = keyterms.length === 0 ? 0 : 1;
+		if (tokenCount + wordTokenCount > MAX_DEEPGRAM_KEYTERM_TOKENS) break;
+		if (
+			queryChars + separatorChars + wordQueryChars >
+			MAX_DEEPGRAM_KEYTERM_QUERY_CHARS
+		) {
+			break;
+		}
+
 		seen.add(dedupeKey);
 		keyterms.push(word);
+		tokenCount += wordTokenCount;
+		queryChars += separatorChars + wordQueryChars;
 
 		if (keyterms.length >= MAX_DEEPGRAM_KEYTERMS) {
 			break;
@@ -26,4 +43,8 @@ export function sanitizeDeepgramKeyterms(boostWords: string[]): string[] {
 	return keyterms;
 }
 
-export { MAX_DEEPGRAM_KEYTERMS };
+export {
+	MAX_DEEPGRAM_KEYTERMS,
+	MAX_DEEPGRAM_KEYTERM_QUERY_CHARS,
+	MAX_DEEPGRAM_KEYTERM_TOKENS,
+};

--- a/src/transcribe/groq.ts
+++ b/src/transcribe/groq.ts
@@ -11,13 +11,40 @@ const BASE_TRANSCRIPTION_PROMPT = [
 	"When the speaker clearly dictates structure, prefer literal symbols for braces, brackets, parentheses, colons, commas, quotes, and slashes.",
 	"Preserve numbered list cues like first, second, and third when spoken.",
 ].join(" ");
+const MAX_TRANSCRIPTION_PROMPT_CHARS = 896;
+
+function fitBoostWordsInPrompt(boostWords: string[]): string[] {
+	const prefix = `${BASE_TRANSCRIPTION_PROMPT} Prefer these terms: `;
+	const suffix = ".";
+	const availableChars =
+		MAX_TRANSCRIPTION_PROMPT_CHARS - prefix.length - suffix.length;
+	if (availableChars <= 0) return [];
+
+	const terms: string[] = [];
+	let usedChars = 0;
+
+	for (const word of boostWords) {
+		const term = word.trim().replace(/\s+/g, " ");
+		if (!term) continue;
+
+		const separatorLength = terms.length === 0 ? 0 : 2;
+		const nextLength = separatorLength + term.length;
+		if (usedChars + nextLength > availableChars) break;
+
+		terms.push(term);
+		usedChars += nextLength;
+	}
+
+	return terms;
+}
 
 function buildTranscriptionPrompt(boostWords: string[]): string {
-	if (boostWords.length === 0) {
+	const fittedBoostWords = fitBoostWordsInPrompt(boostWords);
+	if (fittedBoostWords.length === 0) {
 		return BASE_TRANSCRIPTION_PROMPT;
 	}
 
-	return `${BASE_TRANSCRIPTION_PROMPT} Prefer these terms: ${boostWords.join(", ")}.`;
+	return `${BASE_TRANSCRIPTION_PROMPT} Prefer these terms: ${fittedBoostWords.join(", ")}.`;
 }
 
 function getErrorStatus(error: unknown): number | undefined {
@@ -28,6 +55,8 @@ function getErrorStatus(error: unknown): number | undefined {
 	const { status } = error as { status?: unknown };
 	return typeof status === "number" ? status : undefined;
 }
+
+export { buildTranscriptionPrompt, MAX_TRANSCRIPTION_PROMPT_CHARS };
 
 function getErrorMessage(error: unknown): string | undefined {
 	if (typeof error !== "object" || error === null || !("message" in error)) {

--- a/tests/deepgram-boost.test.ts
+++ b/tests/deepgram-boost.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+	MAX_DEEPGRAM_KEYTERM_QUERY_CHARS,
+	MAX_DEEPGRAM_KEYTERM_TOKENS,
 	MAX_DEEPGRAM_KEYTERMS,
 	sanitizeDeepgramKeyterms,
 } from "../src/transcribe/deepgram-boost";
@@ -20,9 +22,40 @@ describe("sanitizeDeepgramKeyterms", () => {
 	it("caps the list at the Deepgram keyterm limit", () => {
 		const terms = Array.from(
 			{ length: MAX_DEEPGRAM_KEYTERMS + 25 },
-			(_, index) => `term-${index}`,
+			(_, index) => `t${index}`,
 		);
 
 		expect(sanitizeDeepgramKeyterms(terms)).toHaveLength(MAX_DEEPGRAM_KEYTERMS);
+	});
+
+	it("caps the list at the Deepgram token limit", () => {
+		const terms = Array.from(
+			{ length: MAX_DEEPGRAM_KEYTERM_TOKENS + 25 },
+			(_, index) => `term ${index}`,
+		);
+		const keyterms = sanitizeDeepgramKeyterms(terms);
+		const tokenCount = keyterms.reduce(
+			(total, term) => total + term.split(/\s+/).length,
+			0,
+		);
+
+		expect(tokenCount).toBeLessThanOrEqual(MAX_DEEPGRAM_KEYTERM_TOKENS);
+	});
+
+	it("caps encoded keyterms to avoid oversized streaming URLs", () => {
+		const terms = Array.from(
+			{ length: MAX_DEEPGRAM_KEYTERMS },
+			(_, index) => `VERY-LONG-PROJECT-FILENAME-${index}.md`,
+		);
+		const keyterms = sanitizeDeepgramKeyterms(terms);
+		const queryChars = keyterms.reduce(
+			(total, term, index) =>
+				total +
+				(index === 0 ? 0 : 1) +
+				`keyterm=${encodeURIComponent(term)}`.length,
+			0,
+		);
+
+		expect(queryChars).toBeLessThanOrEqual(MAX_DEEPGRAM_KEYTERM_QUERY_CHARS);
 	});
 });

--- a/tests/groq-prompt.test.ts
+++ b/tests/groq-prompt.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildTranscriptionPrompt,
+	MAX_TRANSCRIPTION_PROMPT_CHARS,
+} from "../src/transcribe/groq";
+
+describe("buildTranscriptionPrompt", () => {
+	it("keeps the transcription prompt within Groq's prompt budget", () => {
+		const boostWords = Array.from(
+			{ length: 200 },
+			(_, index) => `VERY-LONG-TECHNICAL-TERM-${index}.md`,
+		);
+
+		const prompt = buildTranscriptionPrompt(boostWords);
+
+		expect(prompt.length).toBeLessThanOrEqual(MAX_TRANSCRIPTION_PROMPT_CHARS);
+	});
+
+	it("prioritizes earlier configured terms when fitting prompt hints", () => {
+		const boostWords = [
+			"Hyprland",
+			"Waybar",
+			"Convex",
+			...Array.from(
+				{ length: 200 },
+				(_, index) => `VERY-LONG-TECHNICAL-TERM-${index}.md`,
+			),
+		];
+
+		const prompt = buildTranscriptionPrompt(boostWords);
+
+		expect(prompt).toContain("Hyprland");
+		expect(prompt).toContain("Waybar");
+		expect(prompt).toContain("Convex");
+		expect(prompt.length).toBeLessThanOrEqual(MAX_TRANSCRIPTION_PROMPT_CHARS);
+	});
+});


### PR DESCRIPTION
## Summary
- Fit Groq transcription prompt hints within the provider prompt budget so long lexicons cannot fail STT requests.
- Cap Deepgram Nova-3 keyterms by term count, documented token count, and encoded query size to avoid oversized streaming URLs.
- Add regression tests for Groq prompt fitting and Deepgram keyterm caps.

## Context
Recent logs showed both providers failing after technical-term lexicon boosting:
- Groq rejected transcription with `prompt length must be 896 characters or fewer`.
- Deepgram streaming failed opening the WebSocket with a very long `keyterm=` query string.

The fix preserves quality by keeping earlier/high-priority configured boost words first, then trimming only overflow terms that would exceed provider budgets.

## Verification
- `bun test tests/groq-prompt.test.ts tests/deepgram-boost.test.ts tests/lexicon.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check src/transcribe/groq.ts src/transcribe/deepgram-boost.ts tests/groq-prompt.test.ts tests/deepgram-boost.test.ts`