### PR TITLE
docs: clarify provider boost lexicon flow

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -196,7 +196,7 @@ The `streaming` option controls whether transcription happens in real-time durin
 
 #### Boost Words (Custom Vocabulary)
 
-The `boostWords` array is used to improve the detection of specific terms like names, acronyms, or technical jargon. Hyprvox also builds a computed project lexicon from boost words, common technical terms, and local repo filenames. That lexicon is passed to Groq, optionally to Deepgram keyterms, and to the merge prompt.
+The `boostWords` array is used to improve the detection of specific terms like names, acronyms, or technical jargon. Hyprvox also builds a computed project lexicon from boost words, common technical terms, and local repo filenames. Provider transcription hints preserve configured boost words and add lexicon terms; the merge prompt receives a smaller capped lexicon plus exact tokens found in the source transcripts.
 
 **Format and Limits:**
 - **Data Type**: Array of strings. Each entry can be a single word or a phrase.

--- a/docs/STT_FLOW.md
+++ b/docs/STT_FLOW.md
@@ -68,7 +68,7 @@ sequenceDiagram
 ### 4. Parallel Transcription
 To minimize latency and maximize accuracy, `hyprvox` executes requests to two separate providers simultaneously using `Promise.all`:
 
-Before provider calls, the daemon builds a local project lexicon from configured boost words, common technical terms, and repo filenames. This improves exact tokens such as `AGENTS.md`, `CRUD`, `SSE`, and `CodeRabbit`.
+Before provider calls, the daemon builds technical-term hints from configured boost words, common technical terms, and repo filenames. Configured boost words are preserved for provider hints, while a smaller computed project lexicon is cached for merge-context hints. This improves exact tokens such as `AGENTS.md`, `CRUD`, `SSE`, and `CodeRabbit`.
 
 1.  **Groq (Whisper Large V3)**:
     - **Strength**: Unrivaled technical accuracy and word recognition.
@@ -79,7 +79,7 @@ Before provider calls, the daemon builds a local project lexicon from configured
 
 **Fallback Logic**: If one service fails, the daemon automatically uses the result from the successful one. If both fail, a critical error notification is shown.
 
-**Technical Term Preservation**: Groq always receives the computed lexicon as prompt terms. Deepgram receives it as `keyterm` hints when `transcription.deepgramBoosting` is enabled.
+**Technical Term Preservation**: Groq always receives provider boost terms as prompt hints. Deepgram receives those terms as `keyterm` hints when `transcription.deepgramBoosting` is enabled. The merge prompt receives the capped project lexicon plus exact tokens found in either source transcript.
 
 **Replay Logging**: The daemon also logs the raw Groq source transcript at info level so merge-quality experiments can replay exact source pairs later.
 


### PR DESCRIPTION
## Summary
- Clarify that provider transcription hints preserve configured boost words and add lexicon terms.
- Distinguish provider boost terms from the capped merge-context lexicon.
- Update STT flow docs to reflect how Groq, Deepgram, and the merger receive term hints.

## Verification
- Docs-only change; Markdown files are ignored by the repo Biome config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how transcription boost words are preserved and utilized during the transcription process.
  * Updated speech-to-text flow documentation with refined details on technical-term hint and lexicon preparation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snehit70/hyprvox/pull/38)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->