### PR TITLE
feat: add long recording quality fallback

### DIFF
--- a/docs/STT_FLOW.md
+++ b/docs/STT_FLOW.md
@@ -89,6 +89,7 @@ If both Groq and Deepgram return results, they are sent to **Llama 3.3 70B** on 
 - **Prompting**: The LLM is instructed to trust Groq for words/technical terms and Deepgram for punctuation/formatting.
 - **Lexicon Hints**: The merge prompt includes known project terms and exact tokens found in either source transcript.
 - **Formatting Mode**: `transcription.formattingMode` controls whether the merge stays close to spoken prose (`verbatim`), lightly cleans sentence boundaries (`clean`), or formats clearly dictated multi-item speech as lists (`structured`).
+- **Long Recording Guard**: For recordings over 90 seconds or transcripts over 150 words, Hyprvox flags merge outputs that expand far beyond both source transcripts and falls back to the fuller source transcript instead of saving likely invented bridge text.
 - **Deduplication**: Automatically removes hallucinations or repeated phrases common in Whisper models.
 - **Latency**: Highly optimized (typically <500ms).
 - **Fallback**: If the LLM call fails or times out, the system defaults to the Deepgram result (for better formatting) or Groq.

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -25,6 +25,7 @@ import {
 } from "../transcribe/deepgram-streaming";
 import { GroqClient } from "../transcribe/groq";
 import { buildContextLexicon } from "../transcribe/lexicon";
+import { assessLongRecordingQuality } from "../transcribe/long-recording";
 import {
 	type MergeReason,
 	type MergeResult,
@@ -90,6 +91,9 @@ interface TranscriptionMetrics {
 	validationRetryCount: number;
 	validationFallbackSource: "none" | "groq" | "deepgram";
 	trimmedHallucinationSuffix: boolean;
+	longRecordingMode: boolean;
+	longRecordingFallbackSource: "none" | "groq" | "deepgram";
+	suspiciousMergeExpansion: boolean;
 	deepgramStopReason: StreamingStopReason | null;
 
 	// Deepgram early-stop observability
@@ -959,6 +963,9 @@ export class DaemonService {
 			validationRetryCount: 0,
 			validationFallbackSource: "none",
 			trimmedHallucinationSuffix: false,
+			longRecordingMode: false,
+			longRecordingFallbackSource: "none",
+			suspiciousMergeExpansion: false,
 			deepgramStopReason: null,
 			deepgramStopWallMs: -1,
 			deepgramCriticalPathMs: -1,
@@ -1351,6 +1358,40 @@ export class DaemonService {
 			metrics.validationRetryCount = recovery.validationRetryCount;
 			metrics.validationFallbackSource = recovery.validationFallbackSource;
 			metrics.trimmedHallucinationSuffix = recovery.validation.trimmedSuffix;
+
+			const longRecordingQuality = assessLongRecordingQuality({
+				recordingDurationMs: duration,
+				finalText,
+				groqText,
+				deepgramText,
+			});
+			metrics.longRecordingMode = longRecordingQuality.isLongRecording;
+			metrics.suspiciousMergeExpansion =
+				longRecordingQuality.suspiciousMergeExpansion;
+			metrics.longRecordingFallbackSource = longRecordingQuality.fallbackSource;
+
+			if (
+				longRecordingQuality.suspiciousMergeExpansion &&
+				longRecordingQuality.fallbackText
+			) {
+				logger.warn(
+					{
+						fallbackSource: longRecordingQuality.fallbackSource,
+						finalTextLength: finalText.length,
+						groqTextLength: groqText.length,
+						deepgramTextLength: deepgramText.length,
+						duration,
+					},
+					"Long recording merge expanded beyond source transcripts; using source fallback",
+				);
+				finalText = longRecordingQuality.fallbackText;
+				accuracy = undefined;
+				metrics.mergeStrategy = "single_source";
+				metrics.mergeReason =
+					longRecordingQuality.fallbackSource === "groq"
+						? "groq_only"
+						: "deepgram_only";
+			}
 
 			if (!recovery.validation.valid) {
 				logger.error(

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -33,6 +33,7 @@ import {
 	TranscriptMerger,
 } from "../transcribe/merger";
 import type { TranscriptQualityReason } from "../transcribe/quality";
+import { validateTranscript } from "../transcribe/quality";
 import { recoverTranscriptQuality } from "../transcribe/recovery";
 import { ErrorTemplates, formatUserError } from "../utils/error-templates";
 import { errorIncludes, getErrorCode } from "../utils/errors";
@@ -1354,10 +1355,11 @@ export class DaemonService {
 			accuracy = recovery.accuracy;
 			metrics.mergeStrategy = recovery.mergeStrategy;
 			metrics.mergeReason = recovery.mergeReason;
-			metrics.validationReasons = recovery.validation.reasons;
+			let finalValidation = recovery.validation;
+			metrics.validationReasons = finalValidation.reasons;
 			metrics.validationRetryCount = recovery.validationRetryCount;
 			metrics.validationFallbackSource = recovery.validationFallbackSource;
-			metrics.trimmedHallucinationSuffix = recovery.validation.trimmedSuffix;
+			metrics.trimmedHallucinationSuffix = finalValidation.trimmedSuffix;
 
 			const longRecordingQuality = assessLongRecordingQuality({
 				recordingDurationMs: duration,
@@ -1385,18 +1387,22 @@ export class DaemonService {
 					"Long recording merge expanded beyond source transcripts; using source fallback",
 				);
 				finalText = longRecordingQuality.fallbackText;
+				finalValidation = validateTranscript(finalText);
+				finalText = finalValidation.text;
 				accuracy = undefined;
 				metrics.mergeStrategy = "single_source";
 				metrics.mergeReason =
 					longRecordingQuality.fallbackSource === "groq"
 						? "groq_only"
 						: "deepgram_only";
+				metrics.validationReasons = finalValidation.reasons;
+				metrics.trimmedHallucinationSuffix = finalValidation.trimmedSuffix;
 			}
 
-			if (!recovery.validation.valid) {
+			if (!finalValidation.valid) {
 				logger.error(
 					{
-						reasons: recovery.validation.reasons,
+						reasons: finalValidation.reasons,
 						text: finalText.substring(0, 200),
 						textLength: finalText.length,
 						duration,
@@ -1409,7 +1415,7 @@ export class DaemonService {
 					"error",
 				);
 				throw new Error(
-					`Transcript validation failed: ${recovery.validation.reasons.join(", ")}`,
+					`Transcript validation failed: ${finalValidation.reasons.join(", ")}`,
 				);
 			}
 

--- a/src/transcribe/long-recording.ts
+++ b/src/transcribe/long-recording.ts
@@ -1,3 +1,5 @@
+import { validateTranscript } from "./quality";
+
 const LONG_RECORDING_DURATION_MS = 90_000;
 const LONG_RECORDING_WORDS = 150;
 const MERGE_EXPANSION_RATIO = 1.35;
@@ -27,13 +29,23 @@ function chooseFallbackSource(
 	groqText: string,
 	deepgramText: string,
 ): { source: LongRecordingFallbackSource; text: string } {
-	if (!groqText && !deepgramText) return { source: "none", text: "" };
-	if (!groqText) return { source: "deepgram", text: deepgramText };
-	if (!deepgramText) return { source: "groq", text: groqText };
+	const candidates = [
+		{
+			source: "deepgram" as const,
+			validation: validateTranscript(deepgramText),
+		},
+		{ source: "groq" as const, validation: validateTranscript(groqText) },
+	].filter(
+		(candidate) => candidate.validation.valid && candidate.validation.text,
+	);
 
-	return deepgramText.length >= groqText.length
-		? { source: "deepgram", text: deepgramText }
-		: { source: "groq", text: groqText };
+	if (candidates.length === 0) return { source: "none", text: "" };
+
+	const fallback = candidates.sort(
+		(a, b) => b.validation.text.length - a.validation.text.length,
+	)[0];
+	if (!fallback) return { source: "none", text: "" };
+	return { source: fallback.source, text: fallback.validation.text };
 }
 
 export function assessLongRecordingQuality({

--- a/src/transcribe/long-recording.ts
+++ b/src/transcribe/long-recording.ts
@@ -1,0 +1,73 @@
+const LONG_RECORDING_DURATION_MS = 90_000;
+const LONG_RECORDING_WORDS = 150;
+const MERGE_EXPANSION_RATIO = 1.35;
+const MERGE_EXPANSION_MIN_EXTRA_CHARS = 120;
+
+export type LongRecordingFallbackSource = "none" | "groq" | "deepgram";
+
+export interface LongRecordingQualityInput {
+	recordingDurationMs: number;
+	finalText: string;
+	groqText: string;
+	deepgramText: string;
+}
+
+export interface LongRecordingQualityResult {
+	isLongRecording: boolean;
+	suspiciousMergeExpansion: boolean;
+	fallbackSource: LongRecordingFallbackSource;
+	fallbackText: string;
+}
+
+function countWords(text: string): number {
+	return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function chooseFallbackSource(
+	groqText: string,
+	deepgramText: string,
+): { source: LongRecordingFallbackSource; text: string } {
+	if (!groqText && !deepgramText) return { source: "none", text: "" };
+	if (!groqText) return { source: "deepgram", text: deepgramText };
+	if (!deepgramText) return { source: "groq", text: groqText };
+
+	return deepgramText.length >= groqText.length
+		? { source: "deepgram", text: deepgramText }
+		: { source: "groq", text: groqText };
+}
+
+export function assessLongRecordingQuality({
+	recordingDurationMs,
+	finalText,
+	groqText,
+	deepgramText,
+}: LongRecordingQualityInput): LongRecordingQualityResult {
+	const longestSourceLength = Math.max(groqText.length, deepgramText.length);
+	const isLongRecording =
+		recordingDurationMs >= LONG_RECORDING_DURATION_MS ||
+		countWords(finalText) >= LONG_RECORDING_WORDS ||
+		countWords(groqText) >= LONG_RECORDING_WORDS ||
+		countWords(deepgramText) >= LONG_RECORDING_WORDS;
+	const suspiciousMergeExpansion =
+		isLongRecording &&
+		longestSourceLength > 0 &&
+		finalText.length - longestSourceLength >= MERGE_EXPANSION_MIN_EXTRA_CHARS &&
+		finalText.length / longestSourceLength >= MERGE_EXPANSION_RATIO;
+	const fallback = suspiciousMergeExpansion
+		? chooseFallbackSource(groqText, deepgramText)
+		: { source: "none" as const, text: "" };
+
+	return {
+		isLongRecording,
+		suspiciousMergeExpansion,
+		fallbackSource: fallback.source,
+		fallbackText: fallback.text,
+	};
+}
+
+export {
+	LONG_RECORDING_DURATION_MS,
+	LONG_RECORDING_WORDS,
+	MERGE_EXPANSION_MIN_EXTRA_CHARS,
+	MERGE_EXPANSION_RATIO,
+};

--- a/tests/long-recording.test.ts
+++ b/tests/long-recording.test.ts
@@ -33,7 +33,7 @@ describe("assessLongRecordingQuality", () => {
 		expect(result.isLongRecording).toBe(true);
 		expect(result.suspiciousMergeExpansion).toBe(true);
 		expect(result.fallbackSource).toBe("deepgram");
-		expect(result.fallbackText).toBe(source);
+		expect(result.fallbackText).toBe(source.trim());
 	});
 
 	it("does not flag small expansion in long recordings", () => {
@@ -63,5 +63,23 @@ describe("assessLongRecordingQuality", () => {
 		});
 
 		expect(result.isLongRecording).toBe(true);
+	});
+
+	it("prefers a validated fallback source over a longer invalid source", () => {
+		const validSource =
+			"Update the daemon service and keep the existing clipboard behavior. ".repeat(
+				8,
+			);
+		const invalidLongerSource = `${validSource} ${"Preserve the following terms. ".repeat(8)}`;
+		const result = assessLongRecordingQuality({
+			recordingDurationMs: LONG_RECORDING_DURATION_MS,
+			finalText: `${invalidLongerSource} ${"This invented bridge sentence was not in either source. ".repeat(8)}`,
+			groqText: validSource,
+			deepgramText: invalidLongerSource,
+		});
+
+		expect(result.suspiciousMergeExpansion).toBe(true);
+		expect(result.fallbackSource).toBe("groq");
+		expect(result.fallbackText).toBe(validSource.trim());
 	});
 });

--- a/tests/long-recording.test.ts
+++ b/tests/long-recording.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+	assessLongRecordingQuality,
+	LONG_RECORDING_DURATION_MS,
+} from "../src/transcribe/long-recording";
+
+describe("assessLongRecordingQuality", () => {
+	it("does not enter long-recording mode for short recordings", () => {
+		const result = assessLongRecordingQuality({
+			recordingDurationMs: 10_000,
+			finalText: "short transcript",
+			groqText: "short transcript",
+			deepgramText: "short transcript",
+		});
+
+		expect(result.isLongRecording).toBe(false);
+		expect(result.suspiciousMergeExpansion).toBe(false);
+		expect(result.fallbackSource).toBe("none");
+	});
+
+	it("flags long merge output that expands far beyond both sources", () => {
+		const source =
+			"We need to update the config and preserve the current behavior. ".repeat(
+				4,
+			);
+		const result = assessLongRecordingQuality({
+			recordingDurationMs: LONG_RECORDING_DURATION_MS,
+			finalText: `${source} ${"This extra invented bridge sentence was not in either source. ".repeat(5)}`,
+			groqText: source,
+			deepgramText: source,
+		});
+
+		expect(result.isLongRecording).toBe(true);
+		expect(result.suspiciousMergeExpansion).toBe(true);
+		expect(result.fallbackSource).toBe("deepgram");
+		expect(result.fallbackText).toBe(source);
+	});
+
+	it("does not flag small expansion in long recordings", () => {
+		const source =
+			"We need to update the config and preserve the current behavior. ".repeat(
+				15,
+			);
+		const result = assessLongRecordingQuality({
+			recordingDurationMs: LONG_RECORDING_DURATION_MS,
+			finalText: `${source} Okay.`,
+			groqText: source,
+			deepgramText: source,
+		});
+
+		expect(result.isLongRecording).toBe(true);
+		expect(result.suspiciousMergeExpansion).toBe(false);
+		expect(result.fallbackSource).toBe("none");
+	});
+
+	it("uses word count as a long-recording signal", () => {
+		const source = "word ".repeat(151);
+		const result = assessLongRecordingQuality({
+			recordingDurationMs: 10_000,
+			finalText: source,
+			groqText: source,
+			deepgramText: source,
+		});
+
+		expect(result.isLongRecording).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Add a long-recording quality policy that detects recordings over 90s or transcripts over 150 words.
- Flag suspicious LLM merge expansion when the merged output grows far beyond both source transcripts.
- Fall back to the fuller source transcript for suspicious long-recording expansions and log metrics for auditability.

## Stack
- Stacked on PR #39 (`feat/faithful-formatting-modes`).
- Review this PR against `feat/faithful-formatting-modes` to see only PR5 changes.

## Commits
- `feat: add long recording quality policy`
- `feat: apply long recording source fallback`
- `docs: describe long recording fallback`

## Verification
- `bun test tests/long-recording.test.ts tests/merger.test.ts tests/config.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check src/transcribe/long-recording.ts src/daemon/service.ts tests/long-recording.test.ts`