### PR TITLE
feat: add Deepgram finalization metrics

### DIFF
--- a/docs/STT_FLOW.md
+++ b/docs/STT_FLOW.md
@@ -83,6 +83,8 @@ Before provider calls, the daemon builds technical-term hints from configured bo
 
 **Replay Logging**: The daemon also logs the raw Groq source transcript at info level so merge-quality experiments can replay exact source pairs later.
 
+**Deepgram Finalization Metrics**: In streaming mode, each session records `deepgramFinalizeWaitMs`, `deepgramCloseWaitMs`, `deepgramEndpointingMs`, `deepgramReceivedFinalChunk`, and `deepgramHadSpeechFinal`. These explain whether stop latency came from waiting for the final transcript, closing the WebSocket, or missing Deepgram finalization signals.
+
 ### 5. LLM-Based Merging
 If both Groq and Deepgram return results, they are sent to **Llama 3.3 70B** on Groq Cloud.
 

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -104,6 +104,9 @@ interface TranscriptionMetrics {
 	deepgramStartedEarly: boolean;
 	deepgramFinalizeWaitMs: number;
 	deepgramCloseWaitMs: number;
+	deepgramEndpointingMs: number;
+	deepgramReceivedFinalChunk: boolean;
+	deepgramHadSpeechFinal: boolean;
 
 	// Outcome
 	engine: string;
@@ -974,6 +977,9 @@ export class DaemonService {
 			deepgramStartedEarly: false,
 			deepgramFinalizeWaitMs: -1,
 			deepgramCloseWaitMs: -1,
+			deepgramEndpointingMs: -1,
+			deepgramReceivedFinalChunk: false,
+			deepgramHadSpeechFinal: false,
 			engine: "",
 			textLength: 0,
 			groqTextLength: 0,
@@ -1010,6 +1016,9 @@ export class DaemonService {
 					stopReason: StreamingStopReason;
 					finalizeWaitMs: number;
 					closeWaitMs: number;
+					endpointingMs: number;
+					receivedFinalChunk: boolean;
+					hadSpeechFinal: boolean;
 				};
 				durationMs: number;
 			};
@@ -1026,6 +1035,9 @@ export class DaemonService {
 							stopReason: "not_connected" as const,
 							finalizeWaitMs: -1,
 							closeWaitMs: -1,
+							endpointingMs: -1,
+							receivedFinalChunk: false,
+							hadSpeechFinal: false,
 						};
 					}),
 				);
@@ -1113,6 +1125,9 @@ export class DaemonService {
 				const streamingResult = deepgramTimed.result;
 				metrics.deepgramFinalizeWaitMs = streamingResult.finalizeWaitMs;
 				metrics.deepgramCloseWaitMs = streamingResult.closeWaitMs;
+				metrics.deepgramEndpointingMs = streamingResult.endpointingMs;
+				metrics.deepgramReceivedFinalChunk = streamingResult.receivedFinalChunk;
+				metrics.deepgramHadSpeechFinal = streamingResult.hadSpeechFinal;
 				const deepgramPostConversionTailMs = Math.max(
 					0,
 					deepgramTimed.durationMs - metrics.conversionMs,

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -46,8 +46,8 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 	private connectionStartTime: number = 0;
 	private chunksSent: number = 0;
 	private audioBuffer: Buffer[] = [];
-	private receivedFinalChunk: boolean = false;
-	private hadSpeechFinal: boolean = false;
+	private stopWindowReceivedFinalChunk: boolean = false;
+	private stopWindowHadSpeechFinal: boolean = false;
 	private static readonly MAX_BUFFER_CHUNKS = 100;
 	private static readonly ENDPOINTING_MS = 300;
 
@@ -75,8 +75,8 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 			this.connectionStartTime = 0;
 			this.chunksSent = 0;
 			this.audioBuffer = [];
-			this.receivedFinalChunk = false;
-			this.hadSpeechFinal = false;
+			this.stopWindowReceivedFinalChunk = false;
+			this.stopWindowHadSpeechFinal = false;
 
 			const keyterms = sanitizeDeepgramKeyterms(boostWords);
 			const options: LiveSchema = {
@@ -113,13 +113,6 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 
 			this.connection.on(LiveTranscriptionEvents.Transcript, (data) => {
 				const transcript = data.channel?.alternatives?.[0]?.transcript;
-				if (data.is_final) {
-					this.receivedFinalChunk = true;
-				}
-				if (data.speech_final) {
-					this.hadSpeechFinal = true;
-				}
-
 				if (transcript && transcript.trim().length > 0) {
 					if (data.speech_final) {
 						this.transcriptChunks.push(transcript.trim());
@@ -127,14 +120,20 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 							{ transcript: transcript.trim(), isFinal: true },
 							"Deepgram chunk finalized (speech_final)",
 						);
-						this.emit("transcript", transcript.trim());
+						this.emit("transcript", transcript.trim(), {
+							isFinal: data.is_final,
+							speechFinal: data.speech_final,
+						});
 					} else if (data.is_final) {
 						this.transcriptChunks.push(transcript.trim());
 						logger.debug(
 							{ transcript: transcript.trim(), isFinal: data.is_final },
 							"Deepgram chunk finalized (is_final)",
 						);
-						this.emit("transcript", transcript.trim());
+						this.emit("transcript", transcript.trim(), {
+							isFinal: data.is_final,
+							speechFinal: data.speech_final,
+						});
 					}
 				}
 			});
@@ -305,6 +304,8 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 		let stopReason: StreamingStopReason = "not_connected";
 		let finalizeWaitMs = 0;
 		let closeWaitMs = 0;
+		let receivedFinalChunk = false;
+		let hadSpeechFinal = false;
 
 		if (this.connection) {
 			try {
@@ -321,13 +322,23 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 						resolve("finalize_timeout");
 					}, DeepgramStreamingTranscriber.FINALIZE_TIMEOUT_MS);
 
-					const transcriptHandler = () => {
+					const transcriptHandler = (
+						_text: string,
+						transcriptData?: {
+							isFinal?: boolean;
+							speechFinal?: boolean;
+						},
+					) => {
+						receivedFinalChunk ||= transcriptData?.isFinal ?? false;
+						hadSpeechFinal ||= transcriptData?.speechFinal ?? false;
 						clearTimeout(timeout);
 						resolve("finalize_transcript");
 					};
 					this.once("transcript", transcriptHandler);
 				});
 				finalizeWaitMs = Date.now() - finalizeStart;
+				this.stopWindowReceivedFinalChunk = receivedFinalChunk;
+				this.stopWindowHadSpeechFinal = hadSpeechFinal;
 
 				// Now close the connection
 				this.connection.requestClose();
@@ -379,8 +390,8 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 				finalizeWaitMs,
 				closeWaitMs,
 				endpointingMs: DeepgramStreamingTranscriber.ENDPOINTING_MS,
-				receivedFinalChunk: this.receivedFinalChunk,
-				hadSpeechFinal: this.hadSpeechFinal,
+				receivedFinalChunk: this.stopWindowReceivedFinalChunk,
+				hadSpeechFinal: this.stopWindowHadSpeechFinal,
 			},
 			"Deepgram streaming transcription complete",
 		);
@@ -392,8 +403,8 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 			finalizeWaitMs,
 			closeWaitMs,
 			endpointingMs: DeepgramStreamingTranscriber.ENDPOINTING_MS,
-			receivedFinalChunk: this.receivedFinalChunk,
-			hadSpeechFinal: this.hadSpeechFinal,
+			receivedFinalChunk: this.stopWindowReceivedFinalChunk,
+			hadSpeechFinal: this.stopWindowHadSpeechFinal,
 		};
 	}
 }

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -309,36 +309,41 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 
 		if (this.connection) {
 			try {
+				const transcriptMetricsHandler = (
+					_text: string,
+					transcriptData?: {
+						isFinal?: boolean;
+						speechFinal?: boolean;
+					},
+				) => {
+					receivedFinalChunk ||= transcriptData?.isFinal ?? false;
+					hadSpeechFinal ||= transcriptData?.speechFinal ?? false;
+				};
+
 				// Flush any buffered audio before closing
+				this.on("transcript", transcriptMetricsHandler);
 				this.connection.finalize();
 				logger.debug("Sent finalize signal to Deepgram");
 
 				// Wait for final transcript after finalize
 				const finalizeStart = Date.now();
 				stopReason = await new Promise<StreamingStopReason>((resolve) => {
+					let settled = false;
 					const timeout = setTimeout(() => {
 						logger.debug("Finalize wait timeout, proceeding");
-						this.off("transcript", transcriptHandler);
+						settled = true;
 						resolve("finalize_timeout");
 					}, DeepgramStreamingTranscriber.FINALIZE_TIMEOUT_MS);
 
-					const transcriptHandler = (
-						_text: string,
-						transcriptData?: {
-							isFinal?: boolean;
-							speechFinal?: boolean;
-						},
-					) => {
-						receivedFinalChunk ||= transcriptData?.isFinal ?? false;
-						hadSpeechFinal ||= transcriptData?.speechFinal ?? false;
+					const finalizeHandler = () => {
+						if (settled) return;
+						settled = true;
 						clearTimeout(timeout);
 						resolve("finalize_transcript");
 					};
-					this.once("transcript", transcriptHandler);
+					this.once("transcript", finalizeHandler);
 				});
 				finalizeWaitMs = Date.now() - finalizeStart;
-				this.stopWindowReceivedFinalChunk = receivedFinalChunk;
-				this.stopWindowHadSpeechFinal = hadSpeechFinal;
 
 				// Now close the connection
 				this.connection.requestClose();
@@ -365,6 +370,9 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 				if (!closeClean) {
 					stopReason = `${stopReason}+close_timeout` as StreamingStopReason;
 				}
+				this.off("transcript", transcriptMetricsHandler);
+				this.stopWindowReceivedFinalChunk = receivedFinalChunk;
+				this.stopWindowHadSpeechFinal = hadSpeechFinal;
 			} catch (error) {
 				logError("Error finishing Deepgram streaming", error);
 			} finally {

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -23,6 +23,9 @@ export interface StreamingResult {
 	stopReason: StreamingStopReason;
 	finalizeWaitMs: number;
 	closeWaitMs: number;
+	endpointingMs: number;
+	receivedFinalChunk: boolean;
+	hadSpeechFinal: boolean;
 }
 
 export interface StreamingFailureReason {
@@ -43,7 +46,10 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 	private connectionStartTime: number = 0;
 	private chunksSent: number = 0;
 	private audioBuffer: Buffer[] = [];
+	private receivedFinalChunk: boolean = false;
+	private hadSpeechFinal: boolean = false;
 	private static readonly MAX_BUFFER_CHUNKS = 100;
+	private static readonly ENDPOINTING_MS = 300;
 
 	// Finalize wait: how long to wait for a final transcript after sending
 	// the finalize signal to Deepgram.  Lower values reduce stop latency
@@ -69,12 +75,14 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 			this.connectionStartTime = 0;
 			this.chunksSent = 0;
 			this.audioBuffer = [];
+			this.receivedFinalChunk = false;
+			this.hadSpeechFinal = false;
 
 			const keyterms = sanitizeDeepgramKeyterms(boostWords);
 			const options: LiveSchema = {
 				model: "nova-3",
 				interim_results: true,
-				endpointing: 300,
+				endpointing: DeepgramStreamingTranscriber.ENDPOINTING_MS,
 				vad_events: true,
 				smart_format: true,
 				encoding: "linear16",
@@ -105,6 +113,12 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 
 			this.connection.on(LiveTranscriptionEvents.Transcript, (data) => {
 				const transcript = data.channel?.alternatives?.[0]?.transcript;
+				if (data.is_final) {
+					this.receivedFinalChunk = true;
+				}
+				if (data.speech_final) {
+					this.hadSpeechFinal = true;
+				}
 
 				if (transcript && transcript.trim().length > 0) {
 					if (data.speech_final) {
@@ -364,6 +378,9 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 				stopReason,
 				finalizeWaitMs,
 				closeWaitMs,
+				endpointingMs: DeepgramStreamingTranscriber.ENDPOINTING_MS,
+				receivedFinalChunk: this.receivedFinalChunk,
+				hadSpeechFinal: this.hadSpeechFinal,
 			},
 			"Deepgram streaming transcription complete",
 		);
@@ -374,6 +391,9 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 			stopReason,
 			finalizeWaitMs,
 			closeWaitMs,
+			endpointingMs: DeepgramStreamingTranscriber.ENDPOINTING_MS,
+			receivedFinalChunk: this.receivedFinalChunk,
+			hadSpeechFinal: this.hadSpeechFinal,
 		};
 	}
 }


### PR DESCRIPTION
## Summary
- Track Deepgram streaming endpointing and finalization signals in the streaming result.
- Thread `deepgramEndpointingMs`, `deepgramReceivedFinalChunk`, and `deepgramHadSpeechFinal` into daemon transcription metrics.
- Document the finalization metrics used for future endpoint tuning.

## Stack
- Stacked on PR #40 (`feat/long-recording-quality-mode`).
- PR #40 is stacked on PR #39 (`feat/faithful-formatting-modes`).
- Review this PR against `feat/long-recording-quality-mode` to see only Deepgram metric changes.

## Verification
- `bun test tests/long-recording.test.ts tests/merger.test.ts tests/config.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check src/transcribe/deepgram-streaming.ts src/daemon/service.ts docs/STT_FLOW.md`