### PR TITLE
feat: harden transcript quality and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ test-audio.*
 benchmark-*.ts
 benchmark-results-*.json
 compare-quality.ts
+
+# local planning scratchpad
+plan.md
+
+# generated model-eval artifacts (keep curated manual summary)
+docs/MODEL-EVAL-*.md
+!docs/MODEL-EVAL-MANUAL-2026-05-15-to-2026-05-19.md

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Under the hood:
 |--------|-------|------|
 | Groq | Whisper V3 | Speed |
 | Deepgram | Nova-3 | Accuracy |
-| LLM merge | — | Best-of-both result |
+| LLM merge | Llama 3.3 70B | Best-of-both result |
 
-Both engines run **in parallel**. Results merge with an LLM. If one fails, the other carries on. The merged text is validated before it ever reaches your clipboard — hallucinated outros trimmed, garbage blocked, technical terms preserved.
+Both engines run **in parallel**. Results merge with an LLM. If one fails, the other carries on. The merged text is validated before it ever reaches your clipboard: hallucinated outros are trimmed, prompt artifacts and reasoning leakage are blocked, injected filename/command bursts are rejected, and technical terms are preserved.
 
 **Median latency: 882ms.** 39× faster than real-time.
 
@@ -158,7 +158,7 @@ Config lives at `~/.config/hypr/vox/config.json`:
 
 ```json
 {
-  "apiKeys": { "groq": "...", "deepgram": "..." },
+  "apiKeys": { "groq": "...", "groqFallback": "...", "deepgram": "..." },
   "transcription": {
     "streaming": true,
     "formattingMode": "clean",
@@ -170,6 +170,7 @@ Config lives at `~/.config/hypr/vox/config.json`:
 | Option | Values | Effect |
 |--------|--------|--------|
 | `streaming` | `true` / `false` | Stream Deepgram during recording for lower latency |
+| `mergeModel` | Groq model ID | LLM used for transcript merge; default is `llama-3.3-70b-versatile` |
 | `formattingMode` | `verbatim` `clean` `structured` | How the merged output is shaped |
 | `boostWords` | string list | Improves recognition of technical terms |
 

--- a/docs/ANALYSIS-2026-05-15-to-2026-05-19.md
+++ b/docs/ANALYSIS-2026-05-15-to-2026-05-19.md
@@ -6,8 +6,8 @@ Window analyzed:
 
 - Start: `2026-05-15T00:00:00Z`
 - End: `2026-05-20T00:00:00Z`
-- Source logs: `~/.config/voice-cli/logs/hyprvox-2026-05-15..19.log`
-- Source history: `~/.config/voice-cli/history.json`
+- Source logs: `~/.config/hypr/vox/logs/hyprvox-2026-05-15..19.log`
+- Source history: `~/.config/hypr/vox/history.json`
 
 ## Dataset
 

--- a/docs/ANALYSIS-2026-05-15-to-2026-05-19.md
+++ b/docs/ANALYSIS-2026-05-15-to-2026-05-19.md
@@ -1,0 +1,117 @@
+# Hyprvox Monitoring Analysis: 2026-05-15 to 2026-05-19
+
+This report analyzes fresh production usage after the PR #39, #40, and #41 quality/observability work landed on `main`.
+
+Window analyzed:
+
+- Start: `2026-05-15T00:00:00Z`
+- End: `2026-05-20T00:00:00Z`
+- Source logs: `~/.config/voice-cli/logs/hyprvox-2026-05-15..19.log`
+- Source history: `~/.config/voice-cli/history.json`
+
+## Dataset
+
+- Perf sessions (`type: "perf"`): **143**
+- Saved history transcripts in window: **143**
+- Groq source transcript log entries: **153**
+
+## Performance Summary
+
+Current window medians:
+
+- `processingMs`: **1689ms**
+- `totalMs`: **1756ms**
+- `recordingDurationMs`: **37641ms**
+- RTF (`processingMs / recordingDurationMs`): **0.04602**
+- Approx ms/word proxy (chars/5): **19.53ms median**
+
+Comparison vs recent pre-window slice (2026-04-18 to 2026-05-04, 83 sessions):
+
+- `processingMs`: **2300ms -> 1689ms** (faster by ~611ms median)
+- `totalMs`: **2335ms -> 1756ms** (faster by ~579ms median)
+- RTF: **0.03960 -> 0.04602** (slightly worse normalized ratio, largely due to shorter median recording lengths in current window)
+
+Interpretation:
+
+- Absolute stop-to-clipboard latency is improved.
+- Normalized ratio should be interpreted together with session mix and utterance length.
+
+## Deepgram Finalization Metrics (PR #41 observability)
+
+- `deepgramStopReason`:
+  - `finalize_timeout`: **133 / 143 (93.0%)**
+  - `finalize_transcript`: **9 / 143 (6.3%)**
+  - `not_connected`: **1 / 143 (0.7%)**
+- `deepgramFinalizeWaitMs`: median **401ms**, p95 **405ms**
+- `deepgramCloseWaitMs`: median **259ms**, p95 **324ms**
+- `deepgramCriticalPathMs`: median **0ms**, p95 **167ms**
+- `deepgramReceivedFinalChunk`: **6.3%**
+- `deepgramHadSpeechFinal`: **4.2%**
+
+Interpretation:
+
+- The overlap optimization remains effective (`deepgramCriticalPathMs` median stays at 0ms).
+- `finalize_timeout` remains dominant. This alone is not enough to justify endpoint tuning yet; quality outcomes must drive changes.
+
+## Merge / Recovery Behavior
+
+- `mergeStrategy` distribution:
+  - `llm`: 125
+  - `minor_diff`: 12
+  - `single_source`: 2
+  - `exact_match`: 2
+  - `normalized_match`: 1
+  - `llm_retry_cleaned`: 1
+- Validation retry attempts (`validationRetryCount > 0`): **2 (1.4%)**
+- Validation fallback source (`validationFallbackSource != none`): **1 (0.7%)**
+- Single-source usage: **2 (1.4%)** (`deepgram_only`: 1, `groq_only`: 1)
+- Long recording mode (`longRecordingMode`): **35 (24.5%)**
+- Suspicious merge expansion: **0**
+- Long recording fallback: **0**
+
+Interpretation:
+
+- Deepgram reliability and merge stability are much better than the earlier degraded period.
+- Long-recording guard did not trigger suspicious expansion in this sample, which is good but should continue to be monitored.
+
+## Quality Outcomes
+
+Saved transcript pattern scan (143 entries):
+
+- Prompt artifact family (`preserve the following`, transcript labels, etc.): **0**
+- Mixed-script garbage: **0**
+- Hallucination outro phrases in final saved text: **1 (0.7%)**
+- Explicit chain-of-thought/meta leakage in saved text: **1 (0.7%)**
+
+Important incident:
+
+- At `2026-05-19T16:50:58Z`, merge retry produced a chain-of-thought style output with `<think>` content and meta-reasoning text, despite `mergeStrategy = "llm_retry_cleaned"` and empty `validationReasons` in final perf metrics.
+- Source signals for that session were weak/noisy (`groqText = "Thank you for watching."`, `deepgramText = "Hey."`), and initial merged output was `[NO_SPEECH_DETECTED]` with retry attempted.
+
+This is currently the most critical new regression in the window.
+
+## Reliability / Errors
+
+- `Processing failed` events: **1**
+- Both services failed: **1**
+- Empty recording event (`Size: 0 bytes`): **1**
+
+Interpretation:
+
+- Empty capture right after restart appears as a rare transient, but daemon behavior should avoid provider calls on zero-byte buffers.
+
+## Assessment Against Current Targets
+
+- Saved instruction/prompt artifacts: effectively **near 0%** in this window.
+- Mixed-script garbage: **0%**.
+- Fallback after failed merge: rare and controlled.
+- New concern: **retry-path reasoning leakage** can still escape in rare cases.
+
+## Recommended Next Steps
+
+Priority order:
+
+1. **P0 fix:** harden retry output validation to reject chain-of-thought/meta text (`<think>`, "the user wants me to", similar reasoning markers).
+2. **P0 fix:** if retry output fails strict guard, prefer validated source fallback or explicit no-speech handling instead of saving retry text.
+3. **P1 fix:** short-circuit zero-byte recordings before provider calls and surface a clean no-speech warning.
+4. Continue collecting 1+ more week of data before endpointing changes; then decide on endpoint tuning from quality outcomes, not timeout rate alone.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,7 +49,7 @@ The transcription cycle follows a strictly orchestrated path (see [STT Flow Deta
 6. **Quality Guard**: `src/transcribe/quality.ts`, `src/transcribe/recovery.ts`, and `src/transcribe/long-recording.ts` validate, repair, trim, or fall back before text reaches output.
 7. **Output**:
    - **Clipboard**: Final text is appended to the system clipboard (Wayland via `wl-copy`, X11 via `clipboardy`).
-   - **History**: Transcription is logged to `~/.config/hyprvox/history.json`.
+   - **History**: Transcription is logged to `~/.config/hypr/vox/history.json`.
    - **Notification**: Desktop notification is sent via `notify-send`.
 
 ## Feature Modules
@@ -80,8 +80,8 @@ For details on using these modules programmatically, see the [Programmatic API R
 - **`groq.ts`**: Integration with Groq Cloud SDK.
 - **`deepgram.ts`**: Integration with Deepgram SDK.
 - **`deepgram-streaming.ts`**: WebSocket streaming path with finalize/close timing metrics.
-- **`merger.ts`**: Deterministic and LLM-backed transcript merge logic, including formatting modes.
-- **`quality.ts`**: Transcript validation for prompt artifacts, hallucination suffixes, mixed-script garbage, and garbage fragments.
+- **`merger.ts`**: Deterministic and LLM-backed transcript merge logic, including formatting modes and rate-limit fallback for merge calls.
+- **`quality.ts`**: Transcript validation for prompt artifacts, CoT/meta leakage, injected technical-token bursts, hallucination suffixes, mixed-script garbage, and garbage fragments.
 - **`recovery.ts`**: Repair and source-fallback policy after validation failure.
 - **`lexicon.ts`**: Local technical-term lexicon used for provider hints and merge context.
 - **`long-recording.ts`**: Long-recording merge expansion guard and validated source fallback selection.
@@ -93,6 +93,7 @@ For details on using these modules programmatically, see the [Programmatic API R
 
 ## Error Handling & Resilience
 - **API Fallback**: If one transcription service fails, the other is used automatically.
+- **Merge-Key Fallback**: If the primary Groq merge key is rate-limited or quota-limited, merge and repair calls can retry with `apiKeys.groqFallback`.
 - **Quality Recovery**: Invalid merged output is repaired once when possible, then falls back to a clean source transcript.
 - **Long Recording Guard**: Suspicious long-recording merge expansion falls back to the longest valid source transcript.
 - **Fail Fast**: Prioritizes speed over exhaustive retries (max 2 attempts).

--- a/docs/AUDIO_DEVICES.md
+++ b/docs/AUDIO_DEVICES.md
@@ -50,7 +50,7 @@ arecord -D YOUR_DEVICE_ID -f S16_LE -r 16000 -c 1 -d 5 test.wav
 
 ## 3. Configuring the Device
 
-Once you have identified the correct device ID, update your `config.json` file located at `~/.config/hyprvox/config.json`.
+Once you have identified the correct device ID, update your `config.json` file located at `~/.config/hypr/vox/config.json`.
 
 Add or modify the `audioDevice` field under the `behavior` section:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,12 +5,12 @@ This document provides a detailed overview of the configuration options availabl
 ## Configuration File
 
 The default configuration file is located at:
-`~/.config/hyprvox/config.json`
+`~/.config/hypr/vox/config.json`
 
 ### Security Requirement
 Since the configuration file contains sensitive API keys, it **must** have restricted file permissions.
 ```bash
-chmod 600 ~/.config/hyprvox/config.json
+chmod 600 ~/.config/hypr/vox/config.json
 ```
 
 ## Environment Variables
@@ -58,8 +58,8 @@ The configuration is a JSON file structured into several sections.
     "audioDevice": "default"
   },
   "paths": {
-    "logs": "~/.config/hyprvox/logs/",
-    "history": "~/.config/hyprvox/history.json"
+    "logs": "~/.config/hypr/vox/logs/",
+    "history": "~/.config/hypr/vox/history.json"
   },
   "transcription": {
     "language": "en",
@@ -150,8 +150,8 @@ File system locations for logs and history. Supports `~` for home directory expa
 
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `logs` | String | `"~/.config/hyprvox/logs/"` | Directory where structured log files are stored. |
-| `history` | String | `"~/.config/hyprvox/history.json"` | Path to the transcription history JSON file. |
+| `logs` | String | `"~/.config/hypr/vox/logs/"` | Directory where structured log files are stored. |
+| `history` | String | `"~/.config/hypr/vox/history.json"` | Path to the transcription history JSON file. |
 
 ---
 
@@ -233,7 +233,7 @@ hyprvox boost lexicon
 
 #### Quality And Observability Notes
 
-Transcript quality checks are not currently configurable. The daemon always validates candidate output for prompt artifacts, detachable hallucination suffixes, mixed-script garbage in English mode, and obvious garbage fragments before saving text to clipboard/history.
+Transcript quality checks are not currently configurable. The daemon always validates candidate output for prompt artifacts, CoT/meta leakage, injected filename/command token bursts, detachable hallucination suffixes, mixed-script garbage in English mode, and obvious garbage fragments before saving text to clipboard/history.
 
 In streaming mode, performance logs include Deepgram finalization observability:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -20,6 +20,7 @@ The application supports the following environment variables:
 ### API Key Fallbacks
 If an API key is missing from `config.json`, the application will fall back to these:
 - `GROQ_API_KEY`: Fallback for `apiKeys.groq`
+- `GROQ_FALLBACK_API_KEY`: Fallback for `apiKeys.groqFallback`
 - `DEEPGRAM_API_KEY`: Fallback for `apiKeys.deepgram`
 
 ### Logging
@@ -42,6 +43,7 @@ The configuration is a JSON file structured into several sections.
 {
   "apiKeys": {
     "groq": "gsk_...",
+    "groqFallback": "gsk_...",
     "deepgram": "00000000-0000-0000-0000-000000000000"
   },
   "behavior": {
@@ -82,6 +84,7 @@ Authentication credentials for the transcription services.
 | Option | Type | Default | Description | Validation Rules | Acquisition URL |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | `groq` | String | N/A | API key for Groq (Whisper V3). | Must start with `gsk_`. | [Groq Console](https://console.groq.com/keys) |
+| `groqFallback` | String | Optional | Secondary Groq API key used only when the primary merge key is rate-limited/quota-limited. | Must start with `gsk_` if provided. | [Groq Console](https://console.groq.com/keys) |
 | `deepgram` | String | N/A | API key for Deepgram (Nova-3). | 40-char hex string or UUID. | [Deepgram Console](https://console.deepgram.com/) |
 
 #### How to obtain API Keys

--- a/docs/MODEL-EVAL-MANUAL-2026-05-15-to-2026-05-19.md
+++ b/docs/MODEL-EVAL-MANUAL-2026-05-15-to-2026-05-19.md
@@ -1,0 +1,76 @@
+# Hyprvox Manual Model Evaluation (Human Review)
+
+Window:
+
+- Source replay window: `2026-05-15` to `2026-05-19` UTC
+- Cases reviewed: `1-130` (130 cases)
+- Cases excluded: `131-143` (13 cases) because `llama-3.3-70b-versatile` regeneration repeatedly hit Groq TPD rate limits
+
+Models compared:
+
+- `qwen/qwen3-32b`
+- `llama-3.3-70b-versatile`
+- `openai/gpt-oss-120b`
+
+Method:
+
+- Case-by-case manual reading of model outputs from replay report:
+  - `docs/MODEL-EVAL-2026-05-15-to-2026-05-19.md`
+- Human rubric (priority order):
+  1. Safety/cleanliness (no CoT leakage, no meta artifacts)
+  2. Faithfulness to spoken content and ordering
+  3. Technical fidelity (terms/filenames/commands)
+  4. Formatting fidelity (no over-rewrite)
+  5. Latency as tie-breaker only
+
+## Consolidated Manual Tally
+
+Per-range reviewer tallies:
+
+- Cases `1-33`: llama `20`, openai `11`, qwen `2`
+- Cases `34-66`: llama `22`, openai `11`, qwen `0`
+- Cases `67-98`: llama `18`, openai `11`, qwen `2`
+- Cases `99-130`: llama `17`, openai `12`, qwen `3`
+
+Total across 130 cases:
+
+- **llama-3.3-70b-versatile: 77 wins**
+- **openai/gpt-oss-120b: 45 wins**
+- **qwen/qwen3-32b: 7 wins**
+
+## Safety Findings
+
+- `qwen/qwen3-32b` repeatedly emitted chain-of-thought/meta leakage (`<think>` and reasoning scaffolding), causing frequent disqualification under rubric priority #1.
+- `openai/gpt-oss-120b` was often clean but more likely than llama to append unrelated prior-case content in several ranges.
+- `llama-3.3-70b-versatile` had the best overall balance of cleanliness + faithfulness.
+
+## Cases Where All Models Were Poor
+
+- `19, 22, 29, 43, 47, 48, 84, 85, 116, 117`
+
+These should be treated as hard replay edge cases (weak/noisy source pair quality, cross-case contamination sensitivity, or incompleteness).
+
+## Excluded Cases
+
+- Excluded from ranking: `131-143`
+- Reason: all llama retries failed due Groq TPD rate limiting during regeneration attempts.
+- As directed, these were not included in final model ranking.
+
+## Recommendation
+
+Primary recommendation:
+
+- Keep/choose **`llama-3.3-70b-versatile`** as default merge model.
+
+Why:
+
+- Highest manual win count (`77/130`)
+- Best safety cleanliness among available outputs in this review
+- Stronger faithfulness consistency than `openai/gpt-oss-120b` in aggregate
+- `qwen/qwen3-32b` currently fails safety expectations due CoT/meta leakage behavior in replay
+
+## Follow-up Actions
+
+1. Add strict post-merge guard to reject CoT/meta leakage patterns even if model output appears otherwise coherent.
+2. Keep manual spot-audit workflow for future model tests, with script metrics as secondary evidence only.
+3. Re-run excluded cases (`131-143`) after rate-limit window resets, then append addendum if ranking changes.

--- a/docs/MODEL-EVAL-MANUAL-2026-05-15-to-2026-05-19.md
+++ b/docs/MODEL-EVAL-MANUAL-2026-05-15-to-2026-05-19.md
@@ -29,13 +29,13 @@ Per-range reviewer tallies:
 
 - Cases `1-33`: llama `20`, openai `11`, qwen `2`
 - Cases `34-66`: llama `22`, openai `11`, qwen `0`
-- Cases `67-98`: llama `18`, openai `11`, qwen `2`
+- Cases `67-98`: llama `18`, openai `12`, qwen `2`
 - Cases `99-130`: llama `17`, openai `12`, qwen `3`
 
 Total across 130 cases:
 
 - **llama-3.3-70b-versatile: 77 wins**
-- **openai/gpt-oss-120b: 45 wins**
+- **openai/gpt-oss-120b: 46 wins**
 - **qwen/qwen3-32b: 7 wins**
 
 ## Safety Findings

--- a/docs/QUALITY-HARDENING-PLAN.md
+++ b/docs/QUALITY-HARDENING-PLAN.md
@@ -1,0 +1,41 @@
+# Transcript Quality Hardening Plan
+
+Source: manual review in `docs/QUALITY-MANUAL-REVIEW-2026-05-13-to-2026-05-19.md`.
+
+## Overall Quality
+
+- 211 transcripts reviewed manually.
+- 154 clean, 29 minor issues, 24 major issues, 4 severe issues.
+- Routine dictation is mostly reliable; failures are concentrated in merge/repair leakage and weak-source edge cases.
+
+## Failure Modes
+
+1. CoT/meta leakage
+   - Risk: unsafe non-speech text reaches clipboard/history.
+   - Cause: LLM merge/repair output passed validation when it contained reasoning scaffolds.
+   - Action: hard-block reasoning/meta markers in `validateTranscript()`.
+2. Injected file/command token tails
+   - Risk: otherwise valid dictation gets polluted by unrelated filenames or command-like garbage.
+   - Cause: model over-completion or prompt/context carry-over under weak/ambiguous sources.
+   - Action: add a conservative orphan technical-token burst guard, then refine with source grounding.
+3. Prompt artifacts
+   - Risk: merge/repair instructions leak into transcript text.
+   - Cause: model boundary failure between instructions and source transcript data.
+   - Action: keep expanding prompt-artifact validators and strengthen repair prompt.
+4. Weak-source drift/truncation
+   - Risk: aggressive merge/repair turns clipped speech into misleading text.
+   - Cause: short or contradictory source pairs give the LLM too much room.
+   - Action: prefer clean source fallback or no-speech when sources are tiny/contradictory.
+
+## Execution Order
+
+1. P0: Add final-gate CoT/meta blocker and regression tests.
+2. P0/P1: Add conservative injected filename/command burst blocker and regression tests.
+3. P1: Tighten repair prompt and post-repair validation tests.
+4. P1: Add source-grounding checks for unsupported technical-token additions.
+5. P1: Add weak-source fallback/no-speech policy.
+
+## Current Pass
+
+- Implement items 1 and the conservative part of item 2 in `src/transcribe/quality.ts`.
+- Add focused tests in `tests/transcript-quality.test.ts` and `tests/transcript-recovery.test.ts`.

--- a/docs/QUALITY-MANUAL-REVIEW-2026-05-13-to-2026-05-19.md
+++ b/docs/QUALITY-MANUAL-REVIEW-2026-05-13-to-2026-05-19.md
@@ -1,0 +1,327 @@
+# Manual Transcript Quality Review: 2026-05-13 to 2026-05-19
+
+This report is a manual, transcript-by-transcript review (no script scoring for quality decisions).
+
+Review rubric per transcript:
+
+- `clean`: faithful and readable, no leakage artifacts
+- `minor_issue`: understandable but with local phrasing/recognition drift
+- `major_issue`: meaningful corruption, injected artifacts, or strong semantic drift
+- `severe_issue`: chain-of-thought/meta leakage or transcript fundamentally unsafe
+
+Leakage categories used:
+
+- `none`
+- `cot/meta`
+- `prompt-artifact`
+- `injected-file-cmd`
+- `outro-hallucination`
+- `mixed-script`
+- `other`
+
+## Consolidated Counts
+
+Total manually reviewed rows: **211**
+
+Quality totals:
+
+- `clean`: **154**
+- `minor_issue`: **29**
+- `major_issue`: **24**
+- `severe_issue`: **4**
+
+Leakage-type totals:
+
+- `none`: **154**
+- `injected-file-cmd`: **18**
+- `prompt-artifact`: **8**
+- `cot/meta`: **3**
+- `other`: **28**
+- `outro-hallucination`: **0**
+- `mixed-script`: **0**
+
+Top observed failure modes:
+
+1. **Injected file/command token tails** (e.g., `test-audio.mp3`, `benchmark-audio.ts`) appended to otherwise good dictation.
+2. **Prompt-artifact contamination** (`Preserve the following ...`) in a subset of transcripts.
+3. **Rare severe CoT/meta leakage** (`<think> ...`) still escaping after retry/repair path.
+4. **Post-repair phrasing corruption** in long dictation segments (semantics mostly retained but degraded precision).
+
+## Priority Fix List (from manual review)
+
+1. `block_cot_meta`
+   - Hard-block `<think>` and internal reasoning/meta scaffolds at final output gate.
+2. `token_injection_guard`
+   - Reject or sanitize isolated injected filename/command token bursts not grounded in both sources.
+3. `tighten_repair_prompt`
+   - Strengthen repair prompt to forbid instruction/meta text and force transcript-only output.
+4. `post_repair_revalidate`
+   - Revalidate repaired output with stricter leakage checks before save.
+5. `source_grounding_guard`
+   - Add source-token grounding check to reduce unrelated carry-over blocks.
+6. `weak_source_no_speech`
+   - For tiny/contradictory source pairs, prefer deterministic no-speech/fallback over aggressive LLM repair.
+
+---
+
+## Batch A (2026-05-13 to 2026-05-14)
+
+| timestamp | quality | leakage_type | fix_tag | note |
+|---|---|---|---|---|
+| 2026-05-13T01:56:07.227Z | minor_issue | none | - | Mostly clear intent, but the ending trails off into an incomplete phrase. |
+| 2026-05-13T01:58:13.863Z | clean | none | - | Clear and coherent request about low-battery notifications and thresholds. |
+| 2026-05-13T02:13:29.324Z | clean | none | - | Transcript is understandable with consistent meaning despite natural speech fillers. |
+| 2026-05-13T02:50:18.325Z | clean | none | - | Clear task framing and no visible leakage artifacts. |
+| 2026-05-13T03:18:50.629Z | clean | none | - | Technical question is preserved well with only minor conversational roughness. |
+| 2026-05-13T03:21:15.019Z | clean | none | - | Multi-part request remains coherent and actionable. |
+| 2026-05-13T03:52:23.345Z | clean | none | - | Accurate short instruction with no obvious hallucinated content. |
+| 2026-05-13T04:07:01.972Z | clean | none | - | Very short but clean command-like utterance. |
+| 2026-05-13T05:54:45.829Z | minor_issue | other | weak_source_no_speech | The phrase is partial/incomplete and likely clipped at utterance boundary. |
+| 2026-05-13T05:55:23.417Z | clean | none | - | Fully intelligible request with no artifacting. |
+| 2026-05-13T06:05:37.508Z | clean | none | - | Concise technical instruction captured correctly. |
+| 2026-05-13T06:13:48.971Z | clean | none | - | Short prompt preserved with no artifact leakage. |
+| 2026-05-13T06:24:11.326Z | clean | none | - | Long transcript stays coherent and structurally intact. |
+| 2026-05-13T06:25:09.574Z | clean | none | - | Clear request and intent preserved. |
+| 2026-05-13T07:11:02.534Z | clean | none | - | Security-review request is accurately transcribed. |
+| 2026-05-13T07:28:38.871Z | clean | none | - | Complex idea is noisy but semantically consistent and usable. |
+| 2026-05-13T07:31:04.131Z | major_issue | prompt-artifact | tighten_repair_prompt | The ending contains injected instruction text (“Preserve the following terms...”) unrelated to spoken intent. |
+| 2026-05-13T07:47:01.623Z | clean | none | - | Clear actionable request with no leakage markers. |
+| 2026-05-13T07:51:34.194Z | clean | none | - | Coherent and context-aligned creative/diagram request. |
+| 2026-05-13T08:32:42.711Z | clean | none | - | Message is understandable and free of obvious artifacts. |
+| 2026-05-13T10:04:29.693Z | clean | none | - | Short planning instruction is clean. |
+| 2026-05-13T10:04:35.975Z | clean | none | - | Simple imperative transcript is accurate. |
+| 2026-05-13T10:31:44.298Z | clean | none | - | Multi-step instruction remains clear and grounded. |
+| 2026-05-13T12:44:08.334Z | major_issue | prompt-artifact | tighten_repair_prompt | Includes injected meta phrase (“Preserve the following terms...”) that does not fit the user request. |
+| 2026-05-13T12:46:20.674Z | major_issue | prompt-artifact | tighten_repair_prompt | Contains spurious prompt-like directive (“Preserve the following commands...”) appended to otherwise valid speech. |
+| 2026-05-13T12:48:49.068Z | clean | none | - | Long utterance is noisy but meaningful and consistent. |
+| 2026-05-13T13:09:17.623Z | clean | none | - | Short question captured correctly. |
+| 2026-05-13T13:11:25.850Z | clean | none | - | Clear request and intent preserved. |
+| 2026-05-13T13:33:40.743Z | clean | none | - | Transcript remains coherent across a long command. |
+| 2026-05-13T13:44:59.993Z | clean | none | - | Clean query with no visible leakage. |
+| 2026-05-13T17:22:45.131Z | minor_issue | other | weak_source_no_speech | Utterance is truncated mid-sentence and loses essential context. |
+| 2026-05-13T17:23:05.155Z | clean | none | - | Follow-up request is understandable and complete. |
+| 2026-05-14T02:38:16.984Z | clean | none | - | Clear kickoff instruction for repo initialization workflow. |
+| 2026-05-14T02:54:39.204Z | clean | none | - | Clean planning request with minor filler only. |
+| 2026-05-14T03:11:37.088Z | major_issue | prompt-artifact | tighten_repair_prompt | Transcript contains multiple injected prompt-like fragments (“Preserve...”) and malformed inserted tokens. |
+| 2026-05-14T03:16:32.071Z | clean | none | - | Coherent clarification and direction without leakage. |
+| 2026-05-14T03:17:49.104Z | minor_issue | none | - | Intent is clear, though filename phrase is slightly garbled (`plan.mb`). |
+| 2026-05-14T03:53:48.471Z | minor_issue | other | weak_source_no_speech | Command is cut off mid-clause and lacks the intended branch name/details. |
+| 2026-05-14T03:57:19.766Z | clean | none | - | Long instruction remains contextually consistent and usable. |
+| 2026-05-14T03:58:50.905Z | clean | none | - | Clear sequencing instruction with no artifact patterns. |
+| 2026-05-14T04:12:02.661Z | clean | none | - | Request is coherent and matches expected analysis context. |
+| 2026-05-14T05:20:23.833Z | clean | none | - | Detailed quality-review instruction is preserved with acceptable disfluencies. |
+| 2026-05-14T05:52:18.510Z | clean | none | - | Short question is correctly captured. |
+| 2026-05-14T05:53:38.496Z | clean | none | - | Clear, concise model-selection request. |
+| 2026-05-14T06:03:56.029Z | clean | none | - | Simple audibility check transcribed correctly. |
+| 2026-05-14T06:15:43.677Z | clean | none | - | Multi-step branch/commit instruction is intelligible. |
+| 2026-05-14T06:17:02.775Z | major_issue | other | post_repair_revalidate | Transcript shows duplicated numbered sections and repetition drift, indicating merge/repair instability. |
+| 2026-05-14T06:20:07.961Z | clean | none | - | Complex feature proposal is long but coherent and grounded. |
+| 2026-05-14T06:24:49.295Z | clean | none | - | Clear implementation and DB cleanup instruction. |
+| 2026-05-14T06:27:53.934Z | clean | none | - | Long planning message is noisy but coherent and grounded. |
+| 2026-05-14T06:28:54.600Z | clean | none | - | Clean concise instruction. |
+| 2026-05-14T06:36:22.979Z | clean | none | - | Audibility check is accurate. |
+| 2026-05-14T06:37:21.253Z | clean | none | - | Clear next-step command with minor typo preserved naturally. |
+| 2026-05-14T06:39:23.482Z | clean | none | - | Short coordination question captured correctly. |
+| 2026-05-14T06:40:27.614Z | clean | none | - | Clear prioritization instruction with no leakage signs. |
+| 2026-05-14T06:45:50.065Z | clean | none | - | Direct question is transcribed accurately. |
+| 2026-05-14T06:49:55.689Z | clean | none | - | Very short question preserved correctly. |
+| 2026-05-14T06:57:28.564Z | major_issue | other | source_grounding_guard | Mid/late segment drifts into unrelated hallucinated phrases and malformed topic jumps. |
+| 2026-05-14T07:02:12.063Z | severe_issue | cot/meta | block_cot_meta | Full chain-of-thought style internal reasoning is leaked directly into transcript text. |
+| 2026-05-14T07:41:01.286Z | clean | none | - | Clear bug report with coherent flow. |
+| 2026-05-14T09:07:38.932Z | clean | none | - | Long planning statement is understandable and context-consistent. |
+| 2026-05-14T09:12:54.641Z | minor_issue | other | post_repair_revalidate | Mostly usable but has heavy disfluency/repetition and local phrase corruption near the end. |
+| 2026-05-14T11:14:51.212Z | clean | none | - | Clear technical explanation request. |
+| 2026-05-14T11:42:40.506Z | clean | none | - | Test-run statement is coherent; file names/tokens are preserved correctly. |
+| 2026-05-14T12:36:53.992Z | clean | none | - | Long instruction is coherent with no obvious leakage artifacts. |
+
+Batch A summary:
+
+- clean: 53
+- minor_issue: 7
+- major_issue: 7
+- severe_issue: 1
+
+---
+
+## Batch B (2026-05-15 to 2026-05-16)
+
+| timestamp | quality | leakage_type | fix_tag | note |
+|---|---|---|---|---|
+| 2026-05-15T02:17:40.006Z | clean | none | - | Clear task instruction about import/validation flow with no leakage markers. |
+| 2026-05-15T03:02:43.422Z | clean | none | - | Short and coherent request about selecting the right SSH public key. |
+| 2026-05-15T03:46:25.074Z | clean | none | - | Transcript is clear and semantically consistent about checking an upload issue screenshot. |
+| 2026-05-15T04:19:45.414Z | minor_issue | other | post_repair_revalidate | Utterance is incomplete/trailing but still understandable as a transition into next task. |
+| 2026-05-15T04:25:37.112Z | clean | none | - | Multi-step planning dictation is long but coherent and usable. |
+| 2026-05-15T06:47:06.862Z | clean | none | - | Clean conversational sentence with no artifact leakage. |
+| 2026-05-15T06:47:30.985Z | clean | none | - | Clean sentence and intent preserved. |
+| 2026-05-15T08:09:10.199Z | clean | none | - | Clear technical ask with constraints preserved. |
+| 2026-05-15T08:10:57.240Z | clean | none | - | Long but coherent workflow question with no visible transcript pollution. |
+| 2026-05-15T08:13:50.874Z | clean | none | - | Clear direct message text with no leakage patterns. |
+| 2026-05-15T08:30:10.205Z | clean | none | - | Short instruction captured accurately and cleanly. |
+| 2026-05-15T08:31:52.575Z | clean | none | - | Detailed planning instruction remains coherent and artifact-free. |
+| 2026-05-15T08:32:35.149Z | clean | none | - | Request is clear and semantically intact. |
+| 2026-05-15T08:40:31.102Z | clean | none | - | Long operational instruction remains coherent without leakage signatures. |
+| 2026-05-15T08:48:54.865Z | clean | none | - | Complex instruction is still readable and semantically consistent. |
+| 2026-05-15T08:50:43.074Z | clean | none | - | Clean short status instruction. |
+| 2026-05-15T09:08:42.330Z | clean | none | - | Structured checklist transcription is accurate and clear. |
+| 2026-05-15T11:51:31.870Z | clean | none | - | Clear multi-step instruction with no artifact or hallucination markers. |
+| 2026-05-15T12:13:40.982Z | clean | none | - | Short clean conversational line. |
+| 2026-05-15T12:22:49.431Z | major_issue | injected-file-cmd | token_injection_guard | Mid-transcript contains spurious file mentions (e.g., `Test-audio.mp3`) and semantic drift noise. |
+| 2026-05-15T12:26:12.035Z | severe_issue | injected-file-cmd | token_injection_guard | Strong corruption with repeated gibberish tokens plus injected file/command-like strings at tail. |
+| 2026-05-15T12:50:06.363Z | clean | none | - | Image-generation request is coherent and cleanly transcribed. |
+| 2026-05-15T13:12:03.974Z | clean | none | - | Coherent prompt refinement request with no obvious leakage. |
+| 2026-05-15T13:47:41.850Z | clean | none | - | Simple branch-creation instruction captured correctly. |
+| 2026-05-15T13:49:20.638Z | clean | none | - | Long task description remains coherent and actionable. |
+| 2026-05-15T13:56:02.153Z | clean | none | - | Clear operational instruction about docs/readme normalization. |
+| 2026-05-15T13:58:05.697Z | minor_issue | other | post_repair_revalidate | Mostly usable but has small lexical corruption (`design.mp`, `product.mp`) likely ASR repair artifacts. |
+| 2026-05-15T14:10:53.512Z | clean | none | - | Detailed UI task is coherent and free from leakage artifacts. |
+| 2026-05-15T14:18:28.616Z | clean | none | - | Strongly worded but semantically clear redesign directive. |
+| 2026-05-15T14:29:55.169Z | major_issue | other | post_repair_revalidate | Contains multiple broken phrases and sentence-fragment drift reducing reliability of intent details. |
+| 2026-05-15T14:34:17.861Z | minor_issue | other | post_repair_revalidate | Generally understandable but includes ASR substitutions (`BSO`) and rough phrasing. |
+| 2026-05-15T14:46:15.285Z | minor_issue | other | post_repair_revalidate | Largely coherent but has minor phrase corruption around feature-bundling instructions. |
+| 2026-05-15T15:24:01.935Z | major_issue | injected-file-cmd | token_injection_guard | Includes non-contextual command/file-like garbage (`Test.audio...`) embedded in valid instruction. |
+| 2026-05-15T15:46:13.126Z | clean | none | - | Clear stacked-PR request with preserved meaning. |
+| 2026-05-15T16:06:56.823Z | major_issue | injected-file-cmd | token_injection_guard | Ends with unrelated injected file tokens after valid PR instruction. |
+| 2026-05-15T16:28:05.496Z | minor_issue | other | post_repair_revalidate | Meaning mostly preserved but includes lexical corruption (`new Shai, Halu`). |
+| 2026-05-15T16:35:01.899Z | clean | none | - | Clean short instruction. |
+| 2026-05-16T02:09:56.088Z | clean | none | - | Coherent feedback request with no leakage indicators. |
+| 2026-05-16T02:13:05.414Z | minor_issue | other | post_repair_revalidate | Intent is clear but includes likely misrecognition (`charge equity`). |
+| 2026-05-16T04:00:36.019Z | minor_issue | other | post_repair_revalidate | Mostly clear but command token (`SSH TRANS`) appears mistranscribed/ambiguous. |
+| 2026-05-16T04:02:18.085Z | clean | none | - | Clear procedural instruction with good sentence integrity. |
+| 2026-05-16T04:18:39.205Z | major_issue | injected-file-cmd | token_injection_guard | Long segment has semantic drift and appended injected file strings repeated at tail. |
+| 2026-05-16T04:21:21.942Z | minor_issue | other | post_repair_revalidate | Core intent is clear but branch name phrase is slightly mangled. |
+| 2026-05-16T04:36:20.383Z | clean | none | - | Clear review request and planning ask. |
+| 2026-05-16T04:37:10.480Z | clean | none | - | Coherent design direction request with no artifact leakage. |
+| 2026-05-16T04:46:00.833Z | clean | none | - | Structured instruction preserved clearly. |
+| 2026-05-16T04:51:57.405Z | clean | none | - | Question is coherent and semantically intact. |
+| 2026-05-16T04:53:19.127Z | clean | none | - | Follow-up clarification captured clearly. |
+| 2026-05-16T04:55:34.224Z | minor_issue | other | post_repair_revalidate | Understandable request with proper-noun ASR distortions. |
+| 2026-05-16T04:57:12.654Z | clean | none | - | Clarification about usage-limit model is coherent. |
+| 2026-05-16T04:58:13.439Z | clean | none | - | Clear timing clarification with no leakage evidence. |
+| 2026-05-16T05:15:20.649Z | major_issue | injected-file-cmd | token_injection_guard | Ends with unrelated injected file tokens despite coherent canary-deployment plan. |
+| 2026-05-16T07:47:57.794Z | clean | none | - | Clean short question. |
+| 2026-05-16T07:49:47.810Z | clean | none | - | Coherent operational correction about docs flow and branching. |
+| 2026-05-16T08:01:24.750Z | clean | none | - | Clean verification question with no artifacts. |
+| 2026-05-16T08:04:17.413Z | major_issue | injected-file-cmd | token_injection_guard | Long valid instruction is contaminated by appended unrelated file tokens at tail. |
+| 2026-05-16T08:11:00.422Z | clean | none | - | Clear product behavior question. |
+| 2026-05-16T08:11:09.757Z | clean | none | - | Clean short question. |
+| 2026-05-16T08:22:54.659Z | major_issue | injected-file-cmd | token_injection_guard | Contains valid UI feedback but includes injected file token sequence mid-text. |
+| 2026-05-16T09:10:38.635Z | minor_issue | other | post_repair_revalidate | Mostly coherent but has lexical disfluencies and malformed phrases reducing precision. |
+| 2026-05-16T09:29:51.571Z | clean | none | - | Clear mobile/PWA feedback and action request. |
+| 2026-05-16T09:40:40.144Z | clean | none | - | Clean short clarification request. |
+| 2026-05-16T09:40:51.258Z | clean | none | - | Clean short clarification request. |
+| 2026-05-16T09:41:46.946Z | clean | none | - | Clear directive to rename and redeploy. |
+| 2026-05-16T09:44:22.076Z | clean | none | - | Clear PR-thread resolution instruction. |
+| 2026-05-16T09:49:13.386Z | clean | none | - | Long feature request remains coherent and structurally sound. |
+| 2026-05-16T09:52:30.887Z | minor_issue | other | post_repair_revalidate | OCR-output idea is understandable but text has sentence-level noise and repair drift. |
+| 2026-05-16T09:53:10.856Z | clean | none | - | Clear PR issue-resolution instruction. |
+| 2026-05-16T10:36:04.830Z | minor_issue | other | post_repair_revalidate | Intent is clear but includes small lexical oddities. |
+| 2026-05-16T11:10:26.236Z | clean | none | - | Clear summarization request. |
+| 2026-05-16T11:11:20.720Z | clean | none | - | Coherent follow-up with no leakage signs. |
+| 2026-05-16T12:26:59.406Z | clean | none | - | Clean project kickoff instruction. |
+| 2026-05-16T13:25:37.744Z | clean | none | - | Coherent corrective feedback and cleanup instruction. |
+| 2026-05-16T13:28:08.549Z | clean | none | - | Clear release-note task with preserved intent. |
+| 2026-05-16T13:37:51.992Z | clean | none | - | Clear branch/review workflow instruction. |
+| 2026-05-16T14:12:46.003Z | clean | none | - | Coherent ideation request for book-writing workflow. |
+| 2026-05-16T14:14:28.703Z | minor_issue | other | post_repair_revalidate | Meaning is preserved but includes minor phrase corruption near the ending. |
+| 2026-05-16T14:15:27.383Z | clean | none | - | Clean concise objective statement. |
+| 2026-05-16T14:17:00.217Z | minor_issue | other | post_repair_revalidate | Mostly clear, with minor lexical corruption (`Sim link`) in execution details. |
+| 2026-05-16T14:20:10.739Z | clean | none | - | Clear conversational workflow direction. |
+| 2026-05-16T14:54:26.867Z | clean | none | - | Coherent database-related feedback with no leakage markers. |
+| 2026-05-16T15:24:11.634Z | minor_issue | other | post_repair_revalidate | Intent is understandable but phrasing is noisy and partially ungrammatical in the middle. |
+| 2026-05-16T16:04:24.898Z | clean | none | - | Clear bug-report style request. |
+| 2026-05-16T16:16:44.569Z | clean | none | - | Detailed database review ask remains coherent and usable. |
+
+Batch B summary:
+
+- clean: 58
+- minor_issue: 17
+- major_issue: 8
+- severe_issue: 1
+
+---
+
+## Batch C (2026-05-17 to 2026-05-18)
+
+| timestamp | quality | leakage_type | fix_tag | note |
+|---|---|---|---|---|
+| 2026-05-17T05:24:15.502Z | clean | none | - | Clear UI-feedback dictation with coherent intent and no leakage artifacts. |
+| 2026-05-17T06:06:30.608Z | clean | none | - | Transcript is long but semantically consistent and task-specific throughout. |
+| 2026-05-17T08:23:10.456Z | clean | none | - | Clean personal-history statement with good sentence continuity. |
+| 2026-05-17T08:35:29.051Z | clean | none | - | Natural explanation of workflow usage with no prompt or token artifacts. |
+| 2026-05-17T08:49:20.840Z | clean | none | - | Coherent process description with only minor spoken-style repetition. |
+| 2026-05-17T08:52:02.372Z | clean | none | - | Clear prototype-first instruction without hallucinated suffixes. |
+| 2026-05-17T08:53:30.526Z | clean | none | - | Structured procedural guidance, no leakage patterns detected. |
+| 2026-05-17T13:09:39.964Z | clean | none | - | Content is noisy but meaning is preserved and grounded in task context. |
+| 2026-05-17T14:25:49.288Z | clean | none | - | Clean planning request with consistent API-focused context. |
+| 2026-05-17T14:28:47.498Z | clean | none | - | Detailed commit/PR strategy is transcribed accurately and coherently. |
+| 2026-05-18T03:59:04.764Z | clean | none | - | Short and clear planning instruction with no artifact leakage. |
+| 2026-05-18T04:06:39.125Z | major_issue | injected-file-cmd | token_injection_guard | Mid-utterance injection (`test-audio.mp3, benchmark-audio.ts`) breaks semantic flow and appears non-speech noise. |
+| 2026-05-18T05:05:59.585Z | major_issue | injected-file-cmd | token_injection_guard | Repeated filename tokens are appended inside normal dictation and clearly not part of user intent. |
+| 2026-05-18T06:10:17.823Z | clean | none | - | Coherent analysis-phase instruction with no leakage signatures. |
+| 2026-05-18T06:10:48.096Z | clean | none | - | Short workflow correction transcribed cleanly despite colloquial phrasing. |
+| 2026-05-18T06:11:27.433Z | clean | none | - | Clear UI-review request with consistent context and no artifacts. |
+| 2026-05-18T06:12:38.089Z | clean | none | - | Harsh tone but transcript itself is accurate and context-aligned. |
+| 2026-05-18T06:26:28.376Z | clean | none | - | Plain operational instruction with good continuity and no injected strings. |
+| 2026-05-18T06:34:50.834Z | major_issue | injected-file-cmd | token_injection_guard | Filename pair is spuriously appended at the end of otherwise valid instructions. |
+| 2026-05-18T06:36:56.827Z | clean | none | - | Slightly disfluent but still semantically faithful and free of leakage artifacts. |
+| 2026-05-18T06:38:52.408Z | major_issue | injected-file-cmd | token_injection_guard | Contains duplicated blocks and injected filename tokens, indicating contamination in decoded text. |
+| 2026-05-18T07:05:53.391Z | clean | none | - | Strongly worded but coherent step-specific feedback with no prompt artifacts. |
+| 2026-05-18T07:07:08.739Z | severe_issue | injected-file-cmd | token_injection_guard | Transcript degrades into a long burst of fake file/URL-like tokens, overwhelming usable content. |
+| 2026-05-18T08:18:33.292Z | clean | none | - | Understandable planning request with no leakage signatures. |
+| 2026-05-18T08:48:52.591Z | clean | none | - | Mostly clean repo-maintenance instruction with coherent intent. |
+| 2026-05-18T10:11:15.236Z | clean | none | - | Clear bug report about upload/scan behavior and expected outcome. |
+| 2026-05-18T10:12:40.240Z | clean | none | - | Concise follow-up bug statement with preserved semantics. |
+| 2026-05-18T10:46:45.017Z | major_issue | injected-file-cmd | token_injection_guard | Includes unrelated filename token sequence injected into an otherwise coherent request. |
+| 2026-05-18T13:59:30.294Z | clean | none | - | Minimal but clean directive without leakage evidence. |
+| 2026-05-18T14:01:14.726Z | clean | none | - | Long instruction remains coherent and grounded with no artifact contamination. |
+| 2026-05-18T16:17:03.518Z | major_issue | injected-file-cmd | token_injection_guard | Non-context filename tokens appear inline and reduce transcript trustworthiness. |
+| 2026-05-18T16:20:25.981Z | clean | none | - | Brief implementation instruction transcribed cleanly. |
+| 2026-05-18T16:29:38.239Z | major_issue | injected-file-cmd | token_injection_guard | Appended filename token pair is unrelated to the spoken OAuth/landing-page request. |
+| 2026-05-18T16:30:20.135Z | clean | none | - | Clean follow-up on auth/image workflow with no detectable leakage. |
+| 2026-05-18T16:57:01.067Z | clean | none | - | Operational git instruction is clear and artifact-free. |
+| 2026-05-18T17:01:02.078Z | clean | none | - | Coherent landing-page critique and constraints, no leakage markers. |
+| 2026-05-18T17:09:12.888Z | minor_issue | cot/meta | block_cot_meta | Mentions internal agent-skill execution (“use impeccable skill”) which is meta-instruction leakage into transcript text. |
+| 2026-05-18T17:25:41.491Z | clean | none | - | Clear design preference query with preserved meaning. |
+| 2026-05-18T17:48:39.501Z | major_issue | injected-file-cmd | token_injection_guard | Filename token injection appears mid-request and is not semantically grounded. |
+| 2026-05-18T17:54:46.011Z | clean | none | - | Valid frontend-data critique and request for field pruning analysis. |
+| 2026-05-18T17:57:26.999Z | major_issue | injected-file-cmd | token_injection_guard | Ends with injected filename tokens after otherwise coherent API/frontend cleanup instructions. |
+
+Batch C summary:
+
+- clean: 31
+- minor_issue: 1
+- major_issue: 8
+- severe_issue: 1
+
+---
+
+## Batch D (2026-05-19)
+
+| timestamp | quality | leakage_type | fix_tag | note |
+|---|---|---|---|---|
+| 2026-05-19T09:03:20.170Z | clean | none | - | Clear task description end-to-end with only normal spoken disfluency. |
+| 2026-05-19T10:08:20.023Z | minor_issue | other | post_repair_revalidate | Meaning is mostly recoverable but wording has noticeable recognition drift. |
+| 2026-05-19T12:48:38.189Z | minor_issue | prompt-artifact | tighten_repair_prompt | Core request is intact but includes likely artifact tail (`test-audio.txt...`). |
+| 2026-05-19T15:28:08.468Z | clean | none | - | Transcript is coherent and complete with no visible leakage. |
+| 2026-05-19T15:42:54.430Z | clean | none | - | Short utterance is accurate and clean. |
+| 2026-05-19T15:43:21.297Z | clean | none | - | Fully coherent instruction with no leakage markers. |
+| 2026-05-19T15:47:46.391Z | clean | none | - | Clear actionable request, no artifacts observed. |
+| 2026-05-19T16:09:15.895Z | clean | none | - | Intent is preserved and text quality is clean. |
+| 2026-05-19T16:25:30.817Z | clean | none | - | Coherent argumentative prompt without obvious transcription corruption. |
+| 2026-05-19T16:29:59.285Z | minor_issue | other | post_repair_revalidate | Main intent is understandable but several terms are mistranscribed. |
+| 2026-05-19T16:32:46.296Z | clean | none | - | Long-form instruction remains coherent and semantically consistent. |
+| 2026-05-19T16:43:40.560Z | minor_issue | prompt-artifact | tighten_repair_prompt | Mostly good transcript but ends with likely injected file-name artifact. |
+| 2026-05-19T16:45:17.135Z | clean | none | - | Quality is good with natural speech fillers only. |
+| 2026-05-19T16:50:58.086Z | severe_issue | cot/meta | block_cot_meta | Output leaks internal chain-of-thought (`<think> ...`) instead of user speech transcript. |
+| 2026-05-19T16:51:48.489Z | clean | none | - | Clear request and no leakage/hallucination signatures. |
+| 2026-05-19T17:38:35.251Z | clean | none | - | Short directive is accurate and clean. |
+| 2026-05-19T17:47:43.333Z | clean | none | - | Coherent planning request with no obvious artifacts. |
+| 2026-05-19T18:03:34.339Z | major_issue | prompt-artifact | source_grounding_guard | After an understandable first paragraph, transcript appends a large nonsensical token block/file-like strings. |
+
+Batch D summary:
+
+- clean: 12
+- minor_issue: 4
+- major_issue: 1
+- severe_issue: 1

--- a/docs/STT_FLOW.md
+++ b/docs/STT_FLOW.md
@@ -79,7 +79,7 @@ Before provider calls, the daemon builds technical-term hints from configured bo
     - **Strength**: Exceptional punctuation, capitalization, and formatting.
     - **Usage**: Primary source for structure.
 
-**Fallback Logic**: If one service fails, the daemon automatically uses the result from the successful one. If both fail, a critical error notification is shown.
+**Fallback Logic**: If one service fails, the daemon automatically uses the result from the successful one. If both fail, a critical error notification is shown. Merge calls can also use `apiKeys.groqFallback` only when the primary Groq merge key hits rate/quota limits.
 
 **Technical Term Preservation**: Groq always receives provider boost terms as prompt hints. Deepgram receives those terms as `keyterm` hints when `transcription.deepgramBoosting` is enabled. The merge prompt receives the capped project lexicon plus exact tokens found in either source transcript.
 
@@ -93,7 +93,7 @@ If both Groq and Deepgram return results, Hyprvox first decides whether determin
 - **Prompting**: When an LLM merge is needed, the model is instructed to trust Groq for words/technical terms and Deepgram for punctuation/formatting.
 - **Lexicon Hints**: The merge prompt includes known project terms and exact tokens found in either source transcript.
 - **Formatting Mode**: `transcription.formattingMode` controls whether the merge stays close to spoken prose (`verbatim`), lightly cleans sentence boundaries (`clean`), or formats clearly dictated multi-item speech as lists (`structured`).
-- **Validation**: Candidate output is checked for prompt artifacts, detachable hallucination suffixes, mixed-script garbage in English mode, and obvious garbage fragments.
+- **Validation**: Candidate output is checked for prompt artifacts, CoT/meta leakage, injected filename/command token bursts, detachable hallucination suffixes, mixed-script garbage in English mode, and obvious garbage fragments.
 - **Repair**: If a merged output fails validation and both source transcripts exist, Hyprvox retries the merge once with a stricter repair prompt.
 - **Source Fallback**: If repair fails, Hyprvox chooses a clean source transcript instead of saving unsafe merged text.
 - **Long Recording Guard**: For recordings over 90 seconds or transcripts over 150 words, Hyprvox flags merge outputs that expand far beyond both source transcripts and falls back to the longest valid source transcript instead of saving likely invented bridge text.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -19,14 +19,14 @@ This guide covers common issues and their solutions for `hyprvox`.
 - **Symptom**: `Error: Daemon is already running (PID: XXXX)`
 - **Fix**: 
   - Stop the existing daemon: `hyprvox stop`.
-  - If the PID file is stale (process is dead), delete it: `rm ~/.config/hyprvox/daemon.pid`.
+  - If the PID file is stale (process is dead), delete it: `rm ~/.config/hypr/vox/daemon.pid`.
 
 ### Configuration Validation Failed
 - **Symptom**: `Config validation failed: ...`
 - **Fix**: 
   - Ensure API keys are present and correctly formatted (Groq starts with `gsk_`, Deepgram is a UUID).
-  - Check `~/.config/hyprvox/config.json` for syntax errors.
-  - Reset config if needed: `rm ~/.config/hyprvox/config.json && hyprvox config init`.
+  - Check `~/.config/hypr/vox/config.json` for syntax errors.
+  - Reset config if needed: `rm ~/.config/hypr/vox/config.json && hyprvox config init`.
 
 ### Permission Denied (Input/Hotkey)
 - **Symptom**: "Failed to bind global hotkey" or native errors related to `/dev/input/`.
@@ -38,7 +38,7 @@ This guide covers common issues and their solutions for `hyprvox`.
 - **Symptom**: `Daemon has crashed too many times and will not auto-restart.`
 - **Fix**: 
   - This happens if the daemon crashes 3 times in 5 minutes.
-  - Check logs for the root cause: `journalctl --user -u hyprvox -f` or `cat ~/.config/hyprvox/logs/daemon.log`.
+  - Check logs for the root cause: `journalctl --user -u hyprvox -f` or `cat ~/.config/hypr/vox/logs/daemon.log`.
   - Fix the underlying issue and restart manually.
 
 ---
@@ -50,7 +50,7 @@ This guide covers common issues and their solutions for `hyprvox`.
 - **Fix**: 
   - Ensure your key starts with `gsk_`.
   - Obtain a new key at the [Groq Cloud Console](https://console.groq.com/keys).
-  - Verify it is correctly placed in `~/.config/hyprvox/config.json`.
+  - Verify it is correctly placed in `~/.config/hypr/vox/config.json`.
 
 ### Deepgram API Key Invalid
 - **Symptom**: "Deepgram API key is invalid or missing" or "Deepgram: Invalid API Key" in logs.
@@ -133,7 +133,7 @@ This guide covers common issues and their solutions for `hyprvox`.
 - **Fix**:
   - **Wayland**: Install `wl-clipboard`.
   - **X11**: Install `xclip` or `xsel`.
-  - Check the fallback file at `~/.config/hyprvox/transcriptions.txt` to see if the transcript was saved there.
+  - Check the fallback file at `~/.config/hypr/vox/transcriptions.txt` to see if the transcript was saved there.
 
 ### Clipboard Access Denied
 - **Symptom**: "Clipboard access denied" notification.
@@ -177,4 +177,4 @@ This guide covers common issues and their solutions for `hyprvox`.
 
 ### Accuracy is Poor
 - **Symptom**: Transcripts contain errors for specific names or terms.
-- **Fix**: Add those terms to the `boostWords` array in `~/.config/hyprvox/config.json`. Note the 450-word limit.
+- **Fix**: Add those terms to the `boostWords` array in `~/.config/hypr/vox/config.json`. Note the 450-word limit.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -123,7 +123,7 @@ bun run index.ts list-mics
 For more information, see the **[Audio Device Selection Guide](AUDIO_DEVICES.md)**.
 
 ### Viewing Logs
-`hyprvox` stores logs in `~/.config/hyprvox/logs/`. You can view them via the CLI:
+`hyprvox` stores logs in `~/.config/hypr/vox/logs/` by default. You can view them via the CLI:
 ```bash
 # See recent logs
 bun run index.ts logs

--- a/scripts/evaluate-merge-models.ts
+++ b/scripts/evaluate-merge-models.ts
@@ -72,7 +72,7 @@ const DEFAULT_MODELS = [
 ];
 const DEFAULT_SLEEP_MS = 1_500;
 const START = new Date("2026-05-15T00:00:00.000Z");
-const END = new Date("2026-05-20T00:00:00.000Z");
+const END = new Date("2026-05-21T00:00:00.000Z");
 const DEFAULT_CONFIG_PATH = join(
 	homedir(),
 	".config",
@@ -130,8 +130,8 @@ function qualityFlags(text: string): QualityFlags {
 function tokenize(text: string): string[] {
 	return text
 		.toLowerCase()
-		.replace(/[^a-z0-9._\-/\s]/g, " ")
-		.split(/\s+/)
+		.replace(/[^\p{L}\p{M}\p{N}._\-/\s]/gu, " ")
+		.split(/\s+/u)
 		.filter(Boolean);
 }
 
@@ -148,28 +148,41 @@ function qualityScore(
 	output: string,
 	flags: QualityFlags,
 ): QualityBreakdown {
-	const source = `${testCase.groq} ${testCase.deepgram}`.trim();
-	const sourceTokens = tokenize(source);
 	const outputTokens = tokenize(output);
-	const sourceFreq = toFreq(sourceTokens);
 	const outputFreq = toFreq(outputTokens);
 
-	let overlap = 0;
-	for (const [token, outCount] of outputFreq.entries()) {
-		overlap += Math.min(outCount, sourceFreq.get(token) ?? 0);
-	}
+	const sourceScores = [testCase.groq, testCase.deepgram]
+		.filter(Boolean)
+		.map((source) => {
+			const sourceTokens = tokenize(source);
+			const sourceFreq = toFreq(sourceTokens);
 
-	const precision = outputTokens.length > 0 ? overlap / outputTokens.length : 0;
-	const recall = sourceTokens.length > 0 ? overlap / sourceTokens.length : 0;
-	const f1 =
-		precision + recall > 0
-			? (2 * precision * recall) / (precision + recall)
-			: 0;
+			let overlap = 0;
+			for (const [token, outCount] of outputFreq.entries()) {
+				overlap += Math.min(outCount, sourceFreq.get(token) ?? 0);
+			}
+
+			const precision =
+				outputTokens.length > 0 ? overlap / outputTokens.length : 0;
+			const recall =
+				sourceTokens.length > 0 ? overlap / sourceTokens.length : 0;
+			const f1 =
+				precision + recall > 0
+					? (2 * precision * recall) / (precision + recall)
+					: 0;
+
+			return { precision, recall, f1 };
+		});
+
+	const bestScore = sourceScores.reduce(
+		(best, candidate) => (candidate.f1 > best.f1 ? candidate : best),
+		sourceScores[0] ?? { precision: 0, recall: 0, f1: 0 },
+	);
 
 	const sourceLen = Math.max(testCase.groq.length, testCase.deepgram.length, 1);
 	const lengthRatio = output.length / sourceLen;
 
-	let score = f1 * 100;
+	let score = bestScore.f1 * 100;
 	if (flags.cotLeak) score -= 60;
 	if (flags.preserveArtifact) score -= 35;
 	if (flags.outroSuffix) score -= 20;
@@ -182,10 +195,16 @@ function qualityScore(
 		score -= 15;
 	}
 
-	if (precision < 0.6) score -= 20;
+	if (bestScore.precision < 0.6) score -= 20;
 
 	const bounded = Math.max(0, Math.min(100, score));
-	return { precision, recall, f1, lengthRatio, score: bounded };
+	return {
+		precision: bestScore.precision,
+		recall: bestScore.recall,
+		f1: bestScore.f1,
+		lengthRatio,
+		score: bounded,
+	};
 }
 
 function detectIssue(text: string): string {
@@ -327,8 +346,8 @@ async function run(): Promise<void> {
 	);
 	const allCases = buildCases();
 	const candidateCases = issuesOnly
-		? allCases.filter(
-				(testCase) => detectIssue(testCase.qwenFinal) !== "quality_issue",
+		? allCases.filter((testCase) =>
+				Object.values(qualityFlags(testCase.qwenFinal)).some(Boolean),
 			)
 		: allCases;
 	const scopedCases =

--- a/scripts/evaluate-merge-models.ts
+++ b/scripts/evaluate-merge-models.ts
@@ -29,6 +29,7 @@ type EvalCase = {
 	timestamp: string;
 	durationMs: number;
 	issue: string;
+	groq: string;
 	deepgram: string;
 	qwenFinal: string;
 };
@@ -43,6 +44,7 @@ type EvalResult = {
 	outputChars?: number;
 	qwenFlags: QualityFlags;
 	modelFlags?: QualityFlags;
+	qualityScore?: number;
 	text?: string;
 	error?: string;
 };
@@ -52,13 +54,25 @@ type QualityFlags = {
 	outroSuffix: boolean;
 	mixedScript: boolean;
 	mentionsTranscriptMeta: boolean;
+	cotLeak: boolean;
 };
 
-const DEFAULT_MODELS = ["llama-3.3-70b-versatile", "openai/gpt-oss-120b"];
-const DEFAULT_CASE_IDS = [120, 145, 158, 160, 203, 210];
-const DEFAULT_SLEEP_MS = 5_000;
-const START = new Date("2026-05-04T13:48:00.000Z");
-const END = new Date("2026-05-14T23:59:59.999Z");
+type QualityBreakdown = {
+	precision: number;
+	recall: number;
+	f1: number;
+	lengthRatio: number;
+	score: number;
+};
+
+const DEFAULT_MODELS = [
+	"qwen/qwen3-32b",
+	"llama-3.3-70b-versatile",
+	"openai/gpt-oss-120b",
+];
+const DEFAULT_SLEEP_MS = 1_500;
+const START = new Date("2026-05-15T00:00:00.000Z");
+const END = new Date("2026-05-20T00:00:00.000Z");
 const DEFAULT_CONFIG_PATH = join(
 	homedir(),
 	".config",
@@ -106,7 +120,72 @@ function qualityFlags(text: string): QualityFlags {
 		mixedScript: hasLatin && hasOtherScript,
 		mentionsTranscriptMeta:
 			/source_[ab]|source a|source b|transcript block/i.test(text),
+		cotLeak:
+			/<\s*think\s*>|<\s*\/\s*think\s*>|the user wants me to|first, i need to check/i.test(
+				text,
+			),
 	};
+}
+
+function tokenize(text: string): string[] {
+	return text
+		.toLowerCase()
+		.replace(/[^a-z0-9._\-/\s]/g, " ")
+		.split(/\s+/)
+		.filter(Boolean);
+}
+
+function toFreq(tokens: string[]): Map<string, number> {
+	const freq = new Map<string, number>();
+	for (const token of tokens) {
+		freq.set(token, (freq.get(token) ?? 0) + 1);
+	}
+	return freq;
+}
+
+function qualityScore(
+	testCase: EvalCase,
+	output: string,
+	flags: QualityFlags,
+): QualityBreakdown {
+	const source = `${testCase.groq} ${testCase.deepgram}`.trim();
+	const sourceTokens = tokenize(source);
+	const outputTokens = tokenize(output);
+	const sourceFreq = toFreq(sourceTokens);
+	const outputFreq = toFreq(outputTokens);
+
+	let overlap = 0;
+	for (const [token, outCount] of outputFreq.entries()) {
+		overlap += Math.min(outCount, sourceFreq.get(token) ?? 0);
+	}
+
+	const precision = outputTokens.length > 0 ? overlap / outputTokens.length : 0;
+	const recall = sourceTokens.length > 0 ? overlap / sourceTokens.length : 0;
+	const f1 =
+		precision + recall > 0
+			? (2 * precision * recall) / (precision + recall)
+			: 0;
+
+	const sourceLen = Math.max(testCase.groq.length, testCase.deepgram.length, 1);
+	const lengthRatio = output.length / sourceLen;
+
+	let score = f1 * 100;
+	if (flags.cotLeak) score -= 60;
+	if (flags.preserveArtifact) score -= 35;
+	if (flags.outroSuffix) score -= 20;
+	if (flags.mixedScript) score -= 20;
+	if (flags.mentionsTranscriptMeta) score -= 20;
+
+	if (lengthRatio > 2.5) {
+		score -= 30;
+	} else if (lengthRatio > 1.8) {
+		score -= 15;
+	}
+
+	if (precision < 0.6) score -= 20;
+
+	const bounded = Math.max(0, Math.min(100, score));
+	return { precision, recall, f1, lengthRatio, score: bounded };
 }
 
 function detectIssue(text: string): string {
@@ -142,11 +221,13 @@ function buildCases(): EvalCase[] {
 	});
 
 	const logFiles = readdirSync(config.paths.logs)
-		.filter((file) => /^hyprvox-2026-05-(0[4-9]|1[0-4])\.log$/.test(file))
+		.filter((file) => /^hyprvox-2026-05-(1[5-9]|20)\.log$/.test(file))
 		.sort();
 
-	const sessions: Array<{ complete: string; chunks: string[] }> = [];
+	const sessions: Array<{ complete: string; chunks: string[]; groq: string }> =
+		[];
 	let current: { chunks: string[] } | null = null;
+	let currentGroq = "";
 
 	for (const file of logFiles) {
 		for (const event of parseJsonLines(join(config.paths.logs, file))) {
@@ -155,14 +236,22 @@ function buildCases(): EvalCase[] {
 
 			if (event.msg === "Recording started") {
 				current = { chunks: [] };
+				currentGroq = "";
 			} else if (
 				current &&
 				event.msg === "Received streaming transcript chunk"
 			) {
 				current.chunks.push(event.text ?? "");
+			} else if (current && event.msg === "Groq source transcript") {
+				currentGroq = event.text ?? "";
 			} else if (current && event.msg === "Transcription complete") {
-				sessions.push({ complete: event.time, chunks: current.chunks });
+				sessions.push({
+					complete: event.time,
+					chunks: current.chunks,
+					groq: currentGroq,
+				});
 				current = null;
+				currentGroq = "";
 			}
 		}
 	}
@@ -195,6 +284,7 @@ function buildCases(): EvalCase[] {
 			timestamp: entry.timestamp,
 			durationMs: entry.duration,
 			issue: detectIssue(entry.text),
+			groq: session?.groq ?? "",
 			deepgram: session?.chunks.join(" ") ?? "",
 			qwenFinal: entry.text,
 		};
@@ -204,6 +294,10 @@ function buildCases(): EvalCase[] {
 function makeUserPrompt(testCase: EvalCase): string {
 	return `Case ${testCase.id}
 Observed issue in current Qwen output: ${testCase.issue}
+
+<groq_source_transcript>
+${testCase.groq}
+</groq_source_transcript>
 
 <current_qwen_final>
 ${testCase.qwenFinal}
@@ -223,17 +317,26 @@ async function run(): Promise<void> {
 	const sleepMs = Number(getArg("sleep-ms") ?? DEFAULT_SLEEP_MS);
 	const limit = Number(getArg("limit") ?? 0);
 	const smoke = hasFlag("smoke");
+	const issuesOnly = hasFlag("issues-only");
+	const caseIds = getArg("case-ids")
+		?.split(",")
+		.map((value) => Number(value.trim()))
+		.filter(Number.isFinite);
 	const models = (getArg("models")?.split(",") ?? DEFAULT_MODELS).map((model) =>
 		model.trim(),
 	);
-	const caseIds = (
-		getArg("case-ids")?.split(",").map(Number) ?? DEFAULT_CASE_IDS
-	)
-		.filter(Number.isFinite)
-		.slice(0, limit > 0 ? limit : undefined);
 	const allCases = buildCases();
-	const cases = allCases.filter((testCase) => caseIds.includes(testCase.id));
-	const selectedCases = smoke ? cases.slice(0, 1) : cases;
+	const candidateCases = issuesOnly
+		? allCases.filter(
+				(testCase) => detectIssue(testCase.qwenFinal) !== "quality_issue",
+			)
+		: allCases;
+	const scopedCases =
+		caseIds && caseIds.length > 0
+			? candidateCases.filter((testCase) => caseIds.includes(testCase.id))
+			: candidateCases;
+	const limitedCases = limit > 0 ? scopedCases.slice(0, limit) : scopedCases;
+	const selectedCases = smoke ? limitedCases.slice(0, 3) : limitedCases;
 	const results: EvalResult[] = [];
 
 	for (const testCase of selectedCases) {
@@ -251,6 +354,8 @@ async function run(): Promise<void> {
 					max_tokens: 1200,
 				});
 				const text = completion.choices[0]?.message?.content?.trim() ?? "";
+				const modelFlags = qualityFlags(text);
+				const breakdown = qualityScore(testCase, text, modelFlags);
 				results.push({
 					caseId: testCase.id,
 					issue: testCase.issue,
@@ -260,7 +365,8 @@ async function run(): Promise<void> {
 					inputChars: userPrompt.length,
 					outputChars: text.length,
 					qwenFlags: qualityFlags(testCase.qwenFinal),
-					modelFlags: qualityFlags(text),
+					modelFlags,
+					qualityScore: breakdown.score,
 					text,
 				});
 				logger.info({
@@ -321,8 +427,45 @@ function renderMarkdown(cases: EvalCase[], results: EvalResult[]): string {
 			).length;
 			const outros = okRows.filter((row) => row.modelFlags?.outroSuffix).length;
 			const mixed = okRows.filter((row) => row.modelFlags?.mixedScript).length;
-			return `| ${model} | ${okRows.length}/${rows.length} | ${avgTime} | ${artifacts} | ${outros} | ${mixed} |`;
+			const meta = okRows.filter(
+				(row) => row.modelFlags?.mentionsTranscriptMeta,
+			).length;
+			const cot = okRows.filter((row) => row.modelFlags?.cotLeak).length;
+			const avgQualityNum = okRows.length
+				? okRows.reduce((sum, row) => sum + (row.qualityScore ?? 0), 0) /
+					okRows.length
+				: 0;
+			const avgQuality = avgQualityNum.toFixed(1);
+			return `| ${model} | ${okRows.length}/${rows.length} | ${avgTime} | ${avgQuality} | ${artifacts} | ${outros} | ${mixed} | ${meta} | ${cot} |`;
 		})
+		.join("\n");
+
+	const ranking = [...byModel.entries()]
+		.map(([model, rows]) => {
+			const okRows = rows.filter((row) => row.ok);
+			const avgQuality =
+				okRows.length > 0
+					? okRows.reduce((sum, row) => sum + (row.qualityScore ?? 0), 0) /
+						okRows.length
+					: 0;
+			const avgTime =
+				okRows.length > 0
+					? okRows.reduce((sum, row) => sum + row.timeMs, 0) / okRows.length
+					: Number.POSITIVE_INFINITY;
+			const successRate = rows.length > 0 ? okRows.length / rows.length : 0;
+			return { model, avgQuality, avgTime, successRate };
+		})
+		.sort((a, b) => {
+			if (b.avgQuality !== a.avgQuality) return b.avgQuality - a.avgQuality;
+			if (b.successRate !== a.successRate) return b.successRate - a.successRate;
+			return a.avgTime - b.avgTime;
+		});
+
+	const rankingRows = ranking
+		.map(
+			(item, idx) =>
+				`| ${idx + 1} | ${item.model} | ${(item.avgQuality || 0).toFixed(1)} | ${(item.successRate * 100).toFixed(1)}% | ${Math.round(item.avgTime)} |`,
+		)
 		.join("\n");
 
 	const caseSections = cases
@@ -335,7 +478,7 @@ function renderMarkdown(cases: EvalCase[], results: EvalResult[]): string {
 					if (!result.ok) {
 						return `#### ${result.model}\n\nFailed: ${result.error}\n`;
 					}
-					return `#### ${result.model}\n\nTime: ${result.timeMs}ms  \nFlags: ${JSON.stringify(result.modelFlags)}\n\n${result.text}\n`;
+					return `#### ${result.model}\n\nTime: ${result.timeMs}ms  \nQuality score: ${(result.qualityScore ?? 0).toFixed(1)} / 100  \nFlags: ${JSON.stringify(result.modelFlags)}\n\n${result.text}\n`;
 				})
 				.join("\n");
 
@@ -343,7 +486,7 @@ function renderMarkdown(cases: EvalCase[], results: EvalResult[]): string {
 
 Timestamp: ${testCase.timestamp}  
 Duration: ${Math.round(testCase.durationMs / 1000)}s  
-Input chars: Qwen ${testCase.qwenFinal.length}, Deepgram ${testCase.deepgram.length}
+Input chars: Groq ${testCase.groq.length}, Qwen ${testCase.qwenFinal.length}, Deepgram ${testCase.deepgram.length}
 
 #### Current Qwen Final
 
@@ -360,20 +503,26 @@ ${resultText}`;
 **Generated:** ${now}  
 **Models tested:** ${[...byModel.keys()].join(", ")}  
 **Cases tested:** ${cases.map((testCase) => testCase.id).join(", ")}  
-**Method:** Compare current saved Qwen output against model outputs generated from current Qwen final text plus reconstructed Deepgram streaming chunks. Full Groq/Whisper source text is not available in historical logs because current code logs only Groq text length.
+**Method:** Replay with real production source pairs from the current monitoring window using logged Groq source transcript + Deepgram streaming chunks + saved final transcript.
 
 ## Summary
 
-| Model | Successful calls | Avg time ms | Preserve artifacts | Outro suffixes | Mixed script |
-|---|---:|---:|---:|---:|---:|
+| Model | Successful calls | Avg time ms | Avg quality score | Preserve artifacts | Outro suffixes | Mixed script | Transcript meta | CoT leak |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
 ${modelRows}
 
 Successful calls: ${successful.length}/${results.length}
 
+## Ranked Recommendation
+
+| Rank | Model | Avg quality score | Success rate | Avg time ms |
+|---:|---|---:|---:|---:|
+${rankingRows}
+
 ## Notes
 
-- This is not a perfect replay of the original merge because historical logs do not contain full Groq/Whisper text.
-- Deepgram chunks and current Qwen final outputs are real production data.
+- Groq source text and Deepgram chunks are from real production sessions in this window.
+- The saved final transcript is used as the baseline reference for comparison.
 - The script intentionally uses minimal Groq parameters: model, messages, temperature, and max_tokens.
 - Calls are throttled with sleep between requests to avoid rate limits.
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -126,6 +126,7 @@ export const loadConfig = (
 	const envConfig = {
 		apiKeys: {
 			groq: process.env.GROQ_API_KEY,
+			groqFallback: process.env.GROQ_FALLBACK_API_KEY,
 			deepgram: process.env.DEEPGRAM_API_KEY,
 		},
 	};
@@ -138,6 +139,9 @@ export const loadConfig = (
 		...parsedFileConfig,
 		apiKeys: {
 			groq: parsedFileConfig.apiKeys?.groq ?? envConfig.apiKeys.groq,
+			groqFallback:
+				parsedFileConfig.apiKeys?.groqFallback ??
+				envConfig.apiKeys.groqFallback,
 			deepgram:
 				parsedFileConfig.apiKeys?.deepgram ?? envConfig.apiKeys.deepgram,
 		},

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -172,7 +172,7 @@ const defaultTranscription = {
 	language: "en",
 	streaming: false,
 	deepgramBoosting: false,
-	mergeModel: "qwen/qwen3-32b",
+	mergeModel: "llama-3.3-70b-versatile",
 	formattingMode: "clean",
 } as const;
 
@@ -186,6 +186,13 @@ export const ApiKeysSchema = z.object({
 		.string()
 		.startsWith("gsk_", { message: "Groq API key must start with 'gsk_'" })
 		.min(10, { message: "Groq API key is too short" }),
+	groqFallback: z
+		.string()
+		.startsWith("gsk_", {
+			message: "Fallback Groq API key must start with 'gsk_'",
+		})
+		.min(10, { message: "Fallback Groq API key is too short" })
+		.optional(),
 	deepgram: z
 		.string()
 		.min(32, { message: "Deepgram API key is too short" })

--- a/src/transcribe/merger.ts
+++ b/src/transcribe/merger.ts
@@ -551,6 +551,47 @@ export class TranscriptMerger {
 	private _cachedApiKey: string | null = null;
 	private contextLexicon: string[] = [];
 
+	private isRateLimitOrQuotaError(error: unknown): boolean {
+		if (!(error instanceof Error)) {
+			return false;
+		}
+		return /rate_limit|quota|429|tokens per day|limit reached/i.test(
+			error.message,
+		);
+	}
+
+	private async createCompletionWithFallback(
+		primaryApiKey: string,
+		fallbackApiKey: string | undefined,
+		request: Parameters<Groq["chat"]["completions"]["create"]>[0],
+		signal?: AbortSignal,
+	) {
+		try {
+			return this.getClient(primaryApiKey).chat.completions.create(request, {
+				signal,
+				timeout: 30000,
+				maxRetries: 0,
+			});
+		} catch (error) {
+			if (!fallbackApiKey || !this.isRateLimitOrQuotaError(error)) {
+				throw error;
+			}
+
+			logger.warn(
+				{
+					reason: error instanceof Error ? error.message : String(error),
+				},
+				"Primary Groq merge key rate-limited; retrying merge with fallback key",
+			);
+
+			return this.getClient(fallbackApiKey).chat.completions.create(request, {
+				signal,
+				timeout: 30000,
+				maxRetries: 0,
+			});
+		}
+	}
+
 	private getClient(apiKey: string): Groq {
 		if (!this._client || this._cachedApiKey !== apiKey) {
 			this._client = new Groq({ apiKey });
@@ -576,6 +617,7 @@ export class TranscriptMerger {
 		const mergeModel = config.transcription.mergeModel;
 		const formattingMode = config.transcription.formattingMode;
 		const apiKey = config.apiKeys.groq;
+		const fallbackApiKey = config.apiKeys.groqFallback;
 		const sourcesMatch = groqText.trim() === deepgramText.trim();
 		const groqIsEmpty = groqText.trim().length === 0;
 		const deepgramIsEmpty = deepgramText.trim().length === 0;
@@ -688,7 +730,9 @@ export class TranscriptMerger {
 
 			const completion = await withRetry(
 				async (signal) => {
-					return await this.getClient(apiKey).chat.completions.create(
+					return await this.createCompletionWithFallback(
+						apiKey,
+						fallbackApiKey,
 						{
 							model: mergeModel,
 							messages: [
@@ -701,7 +745,7 @@ export class TranscriptMerger {
 							reasoning_effort: "none",
 							include_reasoning: false,
 						},
-						{ signal, timeout: 30000, maxRetries: 0 },
+						signal,
 					);
 				},
 				{
@@ -715,7 +759,12 @@ export class TranscriptMerger {
 				},
 			);
 
-			finalText = completion.choices[0]?.message?.content?.trim() || "";
+			finalText =
+				(
+					completion as {
+						choices?: Array<{ message?: { content?: string } }>;
+					}
+				).choices?.[0]?.message?.content?.trim() || "";
 			const timeMs = Date.now() - startTime;
 
 			logger.debug(
@@ -773,6 +822,7 @@ export class TranscriptMerger {
 		const config = loadConfig();
 		const mergeModel = config.transcription.mergeModel;
 		const apiKey = config.apiKeys.groq;
+		const fallbackApiKey = config.apiKeys.groqFallback;
 		const startTime = Date.now();
 		const userPrompt = `Validation failed for reasons: ${reasons.join(", ")}.
 
@@ -803,7 +853,9 @@ ${deepgramText}
 
 		const completion = await withRetry(
 			async (signal) => {
-				return await this.getClient(apiKey).chat.completions.create(
+				return await this.createCompletionWithFallback(
+					apiKey,
+					fallbackApiKey,
 					{
 						model: mergeModel,
 						messages: [
@@ -814,7 +866,7 @@ ${deepgramText}
 						max_tokens: maxTokens,
 						seed: 42,
 					},
-					{ signal, timeout: 30000, maxRetries: 0 },
+					signal,
 				);
 			},
 			{
@@ -828,7 +880,12 @@ ${deepgramText}
 			},
 		);
 
-		const finalText = completion.choices[0]?.message?.content?.trim() || "";
+		const finalText =
+			(
+				completion as {
+					choices?: Array<{ message?: { content?: string } }>;
+				}
+			).choices?.[0]?.message?.content?.trim() || "";
 		logger.debug(
 			{
 				model: mergeModel,

--- a/src/transcribe/merger.ts
+++ b/src/transcribe/merger.ts
@@ -567,11 +567,14 @@ export class TranscriptMerger {
 		signal?: AbortSignal,
 	) {
 		try {
-			return this.getClient(primaryApiKey).chat.completions.create(request, {
-				signal,
-				timeout: 30000,
-				maxRetries: 0,
-			});
+			return await this.getClient(primaryApiKey).chat.completions.create(
+				request,
+				{
+					signal,
+					timeout: 30000,
+					maxRetries: 0,
+				},
+			);
 		} catch (error) {
 			if (!fallbackApiKey || !this.isRateLimitOrQuotaError(error)) {
 				throw error;
@@ -584,11 +587,14 @@ export class TranscriptMerger {
 				"Primary Groq merge key rate-limited; retrying merge with fallback key",
 			);
 
-			return this.getClient(fallbackApiKey).chat.completions.create(request, {
-				signal,
-				timeout: 30000,
-				maxRetries: 0,
-			});
+			return await this.getClient(fallbackApiKey).chat.completions.create(
+				request,
+				{
+					signal,
+					timeout: 30000,
+					maxRetries: 0,
+				},
+			);
 		}
 	}
 

--- a/src/transcribe/quality.ts
+++ b/src/transcribe/quality.ts
@@ -1,5 +1,7 @@
 export type TranscriptQualityReason =
 	| "prompt_artifact"
+	| "cot_meta"
+	| "token_injection"
 	| "hallucination_suffix"
 	| "mixed_script"
 	| "garbage";
@@ -25,6 +27,18 @@ const PROMPT_ARTIFACT_PATTERNS = [
 	/transcript\s+1\b[\s\S]*\btranscript\s+2\b/i,
 ];
 
+const COT_META_PATTERNS = [
+	/<\/?think\b/i,
+	/\b(?:we need to|i need to|i should|let me)\s+(?:answer|analyze|reason|think|figure out)\b/i,
+	/\bthe user (?:wants|asked|is asking|requested)\b/i,
+	/\b(?:my|the) (?:reasoning|analysis|thought process)\b/i,
+	/\bas an ai(?: language model)?\b/i,
+	/\bi(?:'|’)ll provide (?:the )?(?:final )?(?:answer|transcript)\b/i,
+];
+
+const TECHNICAL_TOKEN_PATTERN =
+	/\b(?:[\w.-]+\.(?:ts|tsx|js|jsx|json|md|yml|yaml|toml|py|rs|go|sh|env|log|mp3|wav|m4a)|(?:bun|npm|pnpm|yarn|git|docker|kubectl|terraform|node)\s+[a-z][\w:-]*|[a-z][\w-]*(?:-audio|-test|-benchmark)[\w.-]*)\b/gi;
+
 const DETACHABLE_SUFFIX_PATTERNS = [
 	/\s*(?:thank you for watching|thanks for watching)[.!?\s]*$/i,
 	/\s*(?:please subscribe|like and subscribe|don't forget to like|hit the bell)[.!?\s]*$/i,
@@ -38,6 +52,36 @@ const LATIN_SCRIPT_PATTERN = /\p{Script=Latin}/u;
 
 function hasPromptArtifact(text: string): boolean {
 	return PROMPT_ARTIFACT_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function hasCotMetaLeakage(text: string): boolean {
+	return COT_META_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function hasInjectedTechnicalTokenBurst(text: string): boolean {
+	const matches = [...text.matchAll(TECHNICAL_TOKEN_PATTERN)];
+	if (matches.length < 2) return false;
+
+	const words = text.split(/\s+/).filter(Boolean);
+	const suspiciousTokenCount = matches.filter((match) =>
+		/(?:audio|benchmark|test-audio|\.(?:mp3|wav|m4a)\b)/i.test(match[0]),
+	).length;
+	const repeatedTechnicalTokens = new Set<string>();
+	for (const match of matches) {
+		const token = match[0].toLowerCase();
+		if (
+			matches.filter((candidate) => candidate[0].toLowerCase() === token)
+				.length > 1
+		) {
+			repeatedTechnicalTokens.add(token);
+		}
+	}
+
+	return (
+		(suspiciousTokenCount >= 2 && matches.length >= 3) ||
+		matches.length >= Math.max(4, Math.ceil(words.length * 0.2)) ||
+		(repeatedTechnicalTokens.size > 0 && matches.length >= 4)
+	);
 }
 
 function hasMixedScriptGarbage(text: string): boolean {
@@ -88,6 +132,12 @@ export function validateTranscript(text: string): TranscriptQualityResult {
 	}
 	if (hasPromptArtifact(trimmed.text)) {
 		reasons.push("prompt_artifact");
+	}
+	if (hasCotMetaLeakage(trimmed.text)) {
+		reasons.push("cot_meta");
+	}
+	if (hasInjectedTechnicalTokenBurst(trimmed.text)) {
+		reasons.push("token_injection");
 	}
 	if (hasMixedScriptGarbage(trimmed.text)) {
 		reasons.push("mixed_script");

--- a/src/transcribe/quality.ts
+++ b/src/transcribe/quality.ts
@@ -30,7 +30,7 @@ const PROMPT_ARTIFACT_PATTERNS = [
 const COT_META_PATTERNS = [
 	/<\/?think\b/i,
 	/\b(?:we need to|i need to|i should|let me)\s+(?:answer|analyze|reason|think|figure out)\b/i,
-	/\bthe user (?:wants|asked|is asking|requested)\b/i,
+	/\bthe user (?:wants|asked|is asking|requested)(?:(?:\s*[:,-])|(?:\s+that\b)|(?:\s+me\s+to\b))?/i,
 	/\b(?:my|the) (?:reasoning|analysis|thought process)\b/i,
 	/\bas an ai(?: language model)?\b/i,
 	/\bi(?:'|’)ll provide (?:the )?(?:final )?(?:answer|transcript)\b/i,
@@ -79,8 +79,9 @@ function hasInjectedTechnicalTokenBurst(text: string): boolean {
 
 	return (
 		(suspiciousTokenCount >= 2 && matches.length >= 3) ||
-		matches.length >= Math.max(4, Math.ceil(words.length * 0.2)) ||
-		(repeatedTechnicalTokens.size > 0 && matches.length >= 4)
+		(repeatedTechnicalTokens.size > 0 && matches.length >= 4) ||
+		(matches.length >= Math.max(6, Math.ceil(words.length * 0.25)) &&
+			(suspiciousTokenCount > 0 || repeatedTechnicalTokens.size > 0))
 	);
 }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -15,8 +15,9 @@ describe("Config Loader", () => {
 		if (!require("node:fs").existsSync(TEST_DIR)) {
 			mkdirSync(TEST_DIR, { recursive: true });
 		}
-		process.env.GROQ_API_KEY = "";
-		process.env.DEEPGRAM_API_KEY = "";
+		delete process.env.GROQ_API_KEY;
+		delete process.env.GROQ_FALLBACK_API_KEY;
+		delete process.env.DEEPGRAM_API_KEY;
 		vi.clearAllMocks();
 	});
 
@@ -30,6 +31,7 @@ describe("Config Loader", () => {
 		const configData = {
 			apiKeys: {
 				groq: "gsk_1234567890",
+				groqFallback: "gsk_abcdefghij",
 				deepgram: "4b5c1234-5678-90ab-cdef-1234567890ab",
 			},
 		};
@@ -38,9 +40,25 @@ describe("Config Loader", () => {
 
 		const config = loadConfig(CONFIG_FILE);
 		expect(config.apiKeys.groq).toBe("gsk_1234567890");
+		expect(config.apiKeys.groqFallback).toBe("gsk_abcdefghij");
 		expect(config.apiKeys.deepgram).toBe(
 			"4b5c1234-5678-90ab-cdef-1234567890ab",
 		);
+	});
+
+	test("should load fallback Groq API key from env if missing in file", () => {
+		const configData = {
+			apiKeys: {
+				groq: "gsk_1234567890",
+				deepgram: "4b5c1234-5678-90ab-cdef-1234567890ab",
+			},
+		};
+		writeFileSync(CONFIG_FILE, JSON.stringify(configData));
+		chmodSync(CONFIG_FILE, 0o600);
+		process.env.GROQ_FALLBACK_API_KEY = "gsk_env_fallback_12345";
+
+		const config = loadConfig(CONFIG_FILE, true);
+		expect(config.apiKeys.groqFallback).toBe("gsk_env_fallback_12345");
 	});
 
 	test("should load config when file does not exist (env fallback)", () => {

--- a/tests/transcript-quality.test.ts
+++ b/tests/transcript-quality.test.ts
@@ -96,6 +96,32 @@ describe("transcript quality validation", () => {
 		expect(result.reasons).toContain("mixed_script");
 	});
 
+	it("detects chain-of-thought and meta leakage", () => {
+		const result = validateTranscript(
+			"<think>We need to analyze the user request.</think> The final transcript is update the docs.",
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.reasons).toContain("cot_meta");
+	});
+
+	it("detects injected file and command token bursts", () => {
+		const result = validateTranscript(
+			"Let's run the review and update the plan. test-audio.mp3 benchmark-audio.ts test-audio.mp3",
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.reasons).toContain("token_injection");
+	});
+
+	it("allows ordinary technical tokens in dictated instructions", () => {
+		const result = validateTranscript(
+			"Open AGENTS.md, update README.md, and run bun test after the change.",
+		);
+
+		expect(result.valid).toBe(true);
+	});
+
 	it.each(mixedScriptFixtures)("detects mixed-script fixture: $name", ({
 		input,
 		expectedReasons,

--- a/tests/transcript-recovery.test.ts
+++ b/tests/transcript-recovery.test.ts
@@ -78,6 +78,23 @@ describe("recoverTranscriptQuality", () => {
 		expect(result.accuracy).toBeUndefined();
 	});
 
+	it("falls back when repair returns chain-of-thought leakage", async () => {
+		const result = await recoverTranscriptQuality({
+			finalText: "<think>I should reason about this.</think> Update the docs.",
+			groqText: "Update the docs.",
+			deepgramText: "Update the docs.",
+			mergeStrategy: "llm",
+			mergeReason: "llm_succeeded",
+			repairMerge: async () =>
+				repairResult("The user wants me to output update the docs."),
+		});
+
+		expect(result.initialValidation.reasons).toContain("cot_meta");
+		expect(result.finalText).toBe("Update the docs.");
+		expect(result.validation.valid).toBe(true);
+		expect(result.validationFallbackSource).toBe("deepgram");
+	});
+
 	it("falls back to Groq when Deepgram source is invalid", async () => {
 		const result = await recoverTranscriptQuality({
 			finalText: "Transcript 1 is better. Transcript 2 is worse.",


### PR DESCRIPTION
## Summary
- Harden transcript validation against CoT/meta leakage and injected filename/command token bursts.
- Fix Groq merge fallback retries and keep merge/recovery behavior aligned with the current config/default model.
- Refresh README and docs to reflect the new quality pipeline, fallback key, and config paths.

## Verification
- bun test tests/config.test.ts tests/transcript-quality.test.ts tests/transcript-recovery.test.ts tests/merger.test.ts
- bunx tsc --noEmit
- bunx biome check README.md docs/STT_FLOW.md docs/ARCHITECTURE.md docs/CONFIGURATION.md docs/TROUBLESHOOTING.md docs/USAGE.md docs/AUDIO_DEVICES.md src/transcribe/merger.ts src/transcribe/quality.ts tests/config.test.ts tests/transcript-quality.test.ts tests/transcript-recovery.test.ts scripts/evaluate-merge-models.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback API key support for Groq to handle rate-limit and quota scenarios.
  * Enhanced transcript quality validation to detect chain-of-thought metadata leakage and injected token patterns.

* **Configuration**
  * Updated default merge model to Llama 3.3 70B.
  * Corrected filesystem paths to `~/.config/hypr/vox/`.
  * New `groqFallback` API key configuration option.

* **Documentation**
  * Updated configuration paths and security guidance throughout docs.
  * Added fallback behavior documentation and quality hardening roadmap.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snehit70/hyprvox/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->