### PR TITLE
docs: add overlay/setup ADRs and stats glossary terms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,3 +23,43 @@ _Avoid_: hotkey, shortcut
 **Overlay**:
 The on-screen status surface that reflects live daemon state.
 _Avoid_: popup, HUD
+
+## Observability
+
+**Readiness**:
+Whether the system is configured and *able* to run — config loaded, API keys present, microphone available. Reported as PASS/WARN/FAIL.
+_Avoid_: health (for this meaning), status
+
+**Health**:
+Whether the system is *running well right now* — judged from recent latency, errors, quality failures, and daemon state over the trailing 24h. Reported as GOOD/WARN/BAD.
+_Avoid_: p0, score
+
+**Quality Failure**:
+A transcript that tripped a validation guardrail (prompt artifact, CoT meta, token injection, hallucinated suffix, mixed script, garbage).
+_Avoid_: error, bad transcription
+
+**Anomaly**:
+A current metric breaching its configured threshold (latency, errors, quality, or cache lag).
+_Avoid_: alert, incident
+
+**Regression**:
+A metric that has worsened relative to its own recent baseline.
+_Avoid_: degradation, drop
+
+**Fallback**:
+When the merge could not use both engines and used a single engine's output instead (groq or deepgram).
+_Avoid_: failover, downgrade
+
+**Merge Strategy**:
+The method used to reconcile the two engine transcripts into the [[Merge Result]].
+_Avoid_: algorithm, mode
+
+## Setup
+
+**Profile**:
+A named bundle of config defaults tuned for a device class (e.g. desktop-balanced, laptop-lowpower, container-headless), recommended from detected device signals and applied as a starting point.
+_Avoid_: preset, template
+
+**Verification**:
+Confirming setup actually *works* — a live API-key auth check and, optionally, a real record-to-transcript run. Distinct from [[Readiness]], which only confirms the system is *able* to run (binaries present, config parses).
+_Avoid_: smoke test, validation

--- a/docs/adr/0001-keep-electron-overlay-fix-latency-in-place.md
+++ b/docs/adr/0001-keep-electron-overlay-fix-latency-in-place.md
@@ -1,0 +1,20 @@
+# Keep the Electron overlay; fix show latency in place rather than rewriting in GTK
+
+The overlay felt like it took up to 4s to appear. Timing logs showed this is two
+stacked, fixable delays — a ~1.1s Electron `window.show()` compositor-map cost (the
+window was unmapped via `hide()` when idle) and a ~1s daemon-side `recorder.start()`
+gap (a blocking `execSync("arecord --version")` on the hot path plus waiting for
+arecord's first audio buffer) — **not** inherent Electron overhead.
+
+We chose to keep the overlay window permanently mapped + click-through
+(`setIgnoreMouseEvents(true, { forward: true })`) and move the arecord capability
+check off the hot path, instead of rewriting the overlay in GTK/layer-shell.
+
+GTK was considered for startup speed and resident footprint. Speed turned out to be
+an Electron *bug*, leaving only footprint — which we judged insufficient on its own
+to justify a second-language (Rust/Vala/PyGObject + gtk4-layer-shell) native
+subproject and the dual-backend maintenance a config switch would require.
+
+GTK remains an option **only** if resident memory or crash rate proves problematic
+*after* these fixes, and if pursued it should replace Electron, not coexist behind a
+config switch.

--- a/docs/adr/0002-setup-verification-uses-live-network-ping.md
+++ b/docs/adr/0002-setup-verification-uses-live-network-ping.md
@@ -1,0 +1,15 @@
+# Setup verification makes a live network call by default
+
+Setup previously only proved **Readiness** — that binaries exist and config parses —
+which let a format-valid-but-wrong API key, a muted mic, or a denied permission pass
+setup and only fail on first real use.
+
+We added **Verification**: by default, setup makes a live auth ping to Groq and
+Deepgram to confirm the keys actually work, with a full record-to-transcript run
+available behind `hyprvox setup --verify`.
+
+This is a deliberate trade-off. The upside is catching the most common real failure
+(a bad key) at setup time instead of first use. The costs: setup now performs a
+network call, an offline setup will fail the ping, and the key is sent to the
+provider during setup rather than only at runtime. We judged early, honest failure
+worth those costs; the ping is skippable, so the decision is cheap to revisit.


### PR DESCRIPTION
Adds the decision records and glossary terms that the #44 work depends on, so agents implementing #45–#53 have them in their checkout.

- ADR-0001: keep the Electron overlay, fix show latency in place rather than rewriting in GTK.
- ADR-0002: setup verification makes a live network call by default.
- CONTEXT.md: adds Readiness, Health, Quality Failure, Anomaly, Regression, Fallback, Merge Strategy, Profile, Verification.

Docs-only; no code changes.

Relates to #44