### PR TITLE
fix: keep overlay window mapped

### DIFF
--- a/overlay/src/global.d.ts
+++ b/overlay/src/global.d.ts
@@ -11,6 +11,7 @@ export interface ElectronAPI {
 	onConnectionStatus: (
 		callback: (status: ConnectionStatus) => void,
 	) => () => void;
+	onReconnectExhausted: (callback: () => void) => () => void;
 	onAudioLevel: (
 		callback: (audioLevel: AudioLevelMessage) => void,
 	) => () => void;

--- a/overlay/src/main.ts
+++ b/overlay/src/main.ts
@@ -36,15 +36,11 @@ const DEFAULT_CONFIG: OverlayConfig = {
 	marginBottom: 80,
 };
 
-const SUCCESS_HIDE_DELAY_MS = 1500;
-const ERROR_HIDE_DELAY_MS = 3000;
 const IPC_CONNECTION_TIMEOUT_MS = 5000;
 
 let mainWindow: BrowserWindow | null = null;
 let ipcClient: IPCClient | null = null;
 let previousStatus: string = "idle";
-let hideTimeout: NodeJS.Timeout | null = null;
-let isWindowVisible = false;
 let ipcConnectionTimeout: NodeJS.Timeout | null = null;
 
 process.on("uncaughtException", (err) => {
@@ -72,6 +68,7 @@ function createOverlayWindow(
 		y,
 		frame: false,
 		transparent: true,
+		show: true,
 		alwaysOnTop: true,
 		resizable: false,
 		skipTaskbar: true,
@@ -89,7 +86,7 @@ function createOverlayWindow(
 
 	window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
 	window.setAlwaysOnTop(true, "floating");
-	window.hide();
+	window.setIgnoreMouseEvents(true, { forward: true });
 
 	window.loadFile(path.join(__dirname, "renderer", "index.html"));
 
@@ -154,53 +151,27 @@ function setupIPCClient(): void {
 
 		const currentStatus = state.status;
 
-		if (hideTimeout) {
-			clearTimeout(hideTimeout);
-			hideTimeout = null;
-		}
-
 		switch (currentStatus) {
 			case "idle":
 				if (previousStatus === "processing") {
-					mainWindow.show();
-					isWindowVisible = true;
 					console.log(
-						`[TIMING] Window shown (success), total=${state.timestamp ? Date.now() - state.timestamp : "N/A"}ms`,
+						`[TIMING] Window already mapped (success), total=${state.timestamp ? Date.now() - state.timestamp : "N/A"}ms`,
 					);
-					hideTimeout = setTimeout(() => {
-						if (mainWindow && !mainWindow.isDestroyed()) {
-							mainWindow.hide();
-							isWindowVisible = false;
-						}
-					}, SUCCESS_HIDE_DELAY_MS);
-				} else if (isWindowVisible) {
-					mainWindow.hide();
-					isWindowVisible = false;
 				}
 				break;
 
 			case "error":
-				mainWindow.show();
-				isWindowVisible = true;
 				console.log(
-					`[TIMING] Window shown (error), total=${state.timestamp ? Date.now() - state.timestamp : "N/A"}ms`,
+					`[TIMING] Window already mapped (error), total=${state.timestamp ? Date.now() - state.timestamp : "N/A"}ms`,
 				);
-				hideTimeout = setTimeout(() => {
-					if (mainWindow && !mainWindow.isDestroyed()) {
-						mainWindow.hide();
-						isWindowVisible = false;
-					}
-				}, ERROR_HIDE_DELAY_MS);
 				break;
 
 			case "starting":
 			case "recording":
 			case "processing":
 			case "stopping":
-				mainWindow.show();
-				isWindowVisible = true;
 				console.log(
-					`[TIMING] Window shown (${currentStatus}), total=${state.timestamp ? Date.now() - state.timestamp : "N/A"}ms`,
+					`[TIMING] Window already mapped (${currentStatus}), total=${state.timestamp ? Date.now() - state.timestamp : "N/A"}ms`,
 				);
 				break;
 		}
@@ -222,10 +193,6 @@ function setupIPCClient(): void {
 
 	ipcClient.on("maxReconnectAttemptsReached", () => {
 		console.log("Max reconnect attempts reached, daemon unavailable");
-		if (mainWindow && !mainWindow.isDestroyed() && isWindowVisible) {
-			mainWindow.hide();
-			isWindowVisible = false;
-		}
 	});
 
 	ipcClient.on("connected", () => {

--- a/overlay/src/main.ts
+++ b/overlay/src/main.ts
@@ -193,6 +193,9 @@ function setupIPCClient(): void {
 
 	ipcClient.on("maxReconnectAttemptsReached", () => {
 		console.log("Max reconnect attempts reached, daemon unavailable");
+		if (mainWindow && !mainWindow.isDestroyed()) {
+			mainWindow.webContents.send("reconnect-exhausted");
+		}
 	});
 
 	ipcClient.on("connected", () => {

--- a/overlay/src/preload.ts
+++ b/overlay/src/preload.ts
@@ -32,6 +32,11 @@ const electronAPI = {
 		ipcRenderer.on("connection-status", handler);
 		return () => ipcRenderer.removeListener("connection-status", handler);
 	},
+	onReconnectExhausted: (callback: () => void): (() => void) => {
+		const handler = (): void => callback();
+		ipcRenderer.on("reconnect-exhausted", handler);
+		return () => ipcRenderer.removeListener("reconnect-exhausted", handler);
+	},
 	onAudioLevel: (
 		callback: (audioLevel: AudioLevelMessage) => void,
 	): (() => void) => {

--- a/overlay/src/renderer/useDaemonState.ts
+++ b/overlay/src/renderer/useDaemonState.ts
@@ -58,6 +58,7 @@ export function useDaemonState(): UseDaemonStateResult {
 		useState<ConnectionStatus>("disconnected");
 	const [showSuccess, setShowSuccess] = useState(false);
 	const [hideError, setHideError] = useState(false);
+	const [reconnectExhausted, setReconnectExhausted] = useState(false);
 	const [audioLevel, setAudioLevel] = useState<AudioLevelMessage | null>(null);
 	const prevStatusRef = useRef<DaemonStatus>("idle");
 	const errorTimeoutRef = useRef<number | null>(null);
@@ -68,7 +69,7 @@ export function useDaemonState(): UseDaemonStateResult {
 			return;
 		}
 
-		const unsubState = api.onDaemonState((state: DaemonState) => {
+		const handleDaemonState = (state: DaemonState): void => {
 			const wasProcessing = prevStatusRef.current === "processing";
 			prevStatusRef.current = state.status;
 
@@ -97,13 +98,22 @@ export function useDaemonState(): UseDaemonStateResult {
 				setShowSuccess(true);
 				setTimeout(() => setShowSuccess(false), 1500);
 			}
-		});
+		};
+
+		const unsubState = api.onDaemonState(handleDaemonState);
 
 		const unsubConnection = api.onConnectionStatus(
 			(status: ConnectionStatus) => {
+				if (status !== "disconnected") {
+					setReconnectExhausted(false);
+				}
 				setConnectionStatus(status);
 			},
 		);
+
+		const unsubReconnectExhausted = api.onReconnectExhausted(() => {
+			setReconnectExhausted(true);
+		});
 
 		const unsubAudioLevel = api.onAudioLevel(
 			(nextAudioLevel: AudioLevelMessage) => {
@@ -111,7 +121,7 @@ export function useDaemonState(): UseDaemonStateResult {
 			},
 		);
 
-		void api.getDaemonState().then(setDaemonState);
+		void api.getDaemonState().then(handleDaemonState);
 		void api.getConnectionStatus().then(setConnectionStatus);
 
 		return () => {
@@ -120,6 +130,7 @@ export function useDaemonState(): UseDaemonStateResult {
 			}
 			unsubState();
 			unsubConnection();
+			unsubReconnectExhausted();
 			unsubAudioLevel();
 		};
 	}, []);
@@ -128,11 +139,20 @@ export function useDaemonState(): UseDaemonStateResult {
 		if (showSuccess) {
 			return "success";
 		}
+		if (reconnectExhausted) {
+			return "hidden";
+		}
 		if (hideError && daemonState.status === "error") {
 			return "hidden";
 		}
 		return mapDaemonToOverlay(daemonState.status, connectionStatus);
-	}, [daemonState.status, connectionStatus, showSuccess, hideError]);
+	}, [
+		daemonState.status,
+		connectionStatus,
+		showSuccess,
+		reconnectExhausted,
+		hideError,
+	]);
 
 	return {
 		overlayState: getOverlayState(),

--- a/overlay/src/renderer/useDaemonState.ts
+++ b/overlay/src/renderer/useDaemonState.ts
@@ -23,6 +23,8 @@ interface UseDaemonStateResult {
 	audioLevel: AudioLevelMessage | null;
 }
 
+const ERROR_HIDE_DELAY_MS = 3000;
+
 function mapDaemonToOverlay(
 	daemonStatus: DaemonStatus,
 	connectionStatus: ConnectionStatus,
@@ -55,8 +57,10 @@ export function useDaemonState(): UseDaemonStateResult {
 	const [connectionStatus, setConnectionStatus] =
 		useState<ConnectionStatus>("disconnected");
 	const [showSuccess, setShowSuccess] = useState(false);
+	const [hideError, setHideError] = useState(false);
 	const [audioLevel, setAudioLevel] = useState<AudioLevelMessage | null>(null);
 	const prevStatusRef = useRef<DaemonStatus>("idle");
+	const errorTimeoutRef = useRef<number | null>(null);
 
 	useEffect(() => {
 		const api = window.electronAPI;
@@ -69,6 +73,21 @@ export function useDaemonState(): UseDaemonStateResult {
 			prevStatusRef.current = state.status;
 
 			setDaemonState(state);
+
+			if (errorTimeoutRef.current !== null) {
+				window.clearTimeout(errorTimeoutRef.current);
+				errorTimeoutRef.current = null;
+			}
+
+			if (state.status === "error") {
+				setHideError(false);
+				errorTimeoutRef.current = window.setTimeout(() => {
+					setHideError(true);
+					errorTimeoutRef.current = null;
+				}, ERROR_HIDE_DELAY_MS);
+			} else {
+				setHideError(false);
+			}
 
 			if (state.status !== "recording") {
 				setAudioLevel(null);
@@ -96,6 +115,9 @@ export function useDaemonState(): UseDaemonStateResult {
 		void api.getConnectionStatus().then(setConnectionStatus);
 
 		return () => {
+			if (errorTimeoutRef.current !== null) {
+				window.clearTimeout(errorTimeoutRef.current);
+			}
 			unsubState();
 			unsubConnection();
 			unsubAudioLevel();
@@ -106,8 +128,11 @@ export function useDaemonState(): UseDaemonStateResult {
 		if (showSuccess) {
 			return "success";
 		}
+		if (hideError && daemonState.status === "error") {
+			return "hidden";
+		}
 		return mapDaemonToOverlay(daemonState.status, connectionStatus);
-	}, [daemonState.status, connectionStatus, showSuccess]);
+	}, [daemonState.status, connectionStatus, showSuccess, hideError]);
 
 	return {
 		overlayState: getOverlayState(),


### PR DESCRIPTION
Closes #45

## Summary
- keep the Electron overlay BrowserWindow mapped instead of hiding/unmapping it on idle or after status transitions
- make the overlay window click-through with setIgnoreMouseEvents(true, { forward: true })
- move the previous timed error disappearance into renderer state so the native window stays mapped

## Verification
- bun run tsc --noEmit
- bun test
- bun x npm pack
- cd overlay && bun run build

## Manual criteria
- First-show timing and desktop click-through require device verification via [TIMING] overlay logs and pointer behavior. The code path plausibly implements both by removing hide/show remapping and setting OS-level click-through, but I did not claim device verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Overlay window now displays immediately on launch
  * Mouse events on the overlay are now properly forwarded to underlying windows
  * Overlay automatically hides after the daemon enters an error state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->