### PR TITLE
fix: move arecord check off recording path

### DIFF
--- a/src/audio/recorder.ts
+++ b/src/audio/recorder.ts
@@ -21,8 +21,30 @@ export interface PcmAudioPayload {
 	bitsPerSample: 16;
 }
 
+type RecordingFactory = typeof record;
+
+export interface AudioRecorderOptions {
+	createRecording?: RecordingFactory;
+	loadConfigFn?: typeof loadConfig;
+}
+
+export function assertAudioBackendAvailable(
+	check: () => void = () => execSync("arecord --version", { stdio: "ignore" }),
+): void {
+	try {
+		check();
+	} catch (_e) {
+		throw new AppError(
+			"AUDIO_BACKEND_MISSING",
+			"Audio recording backend 'arecord' is not installed or not in PATH.",
+		);
+	}
+}
+
 export class AudioRecorder extends EventEmitter {
 	private recording: Recording | null = null;
+	private readonly createRecording: RecordingFactory;
+	private readonly loadConfigFn: typeof loadConfig;
 	private chunks: Buffer[] = [];
 	private startTime: number = 0;
 	private timer: ReturnType<typeof setTimeout> | null = null;
@@ -33,14 +55,16 @@ export class AudioRecorder extends EventEmitter {
 	private isStopping: boolean = false;
 	private pcmExtractor = new PcmStreamExtractor();
 
-	constructor() {
+	constructor(options: AudioRecorderOptions = {}) {
 		super();
+		this.createRecording = options.createRecording ?? record;
+		this.loadConfigFn = options.loadConfigFn ?? loadConfig;
 		this.loadSettings();
 	}
 
 	private loadSettings() {
 		try {
-			const config = loadConfig();
+			const config = this.loadConfigFn();
 			this.minDuration = (config.behavior.clipboard.minDuration || 0.6) * 1000;
 			this.maxDuration = (config.behavior.clipboard.maxDuration || 600) * 1000;
 		} catch (e) {
@@ -66,22 +90,14 @@ export class AudioRecorder extends EventEmitter {
 		this.pcmExtractor.reset();
 		this.startTime = Date.now();
 
-		const config = loadConfig();
-
-		try {
-			execSync("arecord --version", { stdio: "ignore" });
-		} catch (_e) {
-			throw new AppError(
-				"AUDIO_BACKEND_MISSING",
-				"Audio recording backend 'arecord' is not installed or not in PATH.",
-			);
-		}
+		const config = this.loadConfigFn();
+		let startEmitted = false;
 
 		await withRetry(
 			async () => {
 				return new Promise<void>((resolve, reject) => {
 					try {
-						this.recording = record({
+						this.recording = this.createRecording({
 							sampleRate: 16000,
 							channels: 1,
 							audioType: "wav",
@@ -98,6 +114,16 @@ export class AudioRecorder extends EventEmitter {
 
 						const stream = this.recording.stream();
 						let streamStarted = false;
+
+						if (!startEmitted) {
+							this.setupTimers();
+							logger.info(
+								{ device: config.behavior.audioDevice },
+								"Recording started",
+							);
+							this.emit("start");
+							startEmitted = true;
+						}
 
 						stream.on("data", (chunk: Buffer | string) => {
 							if (!streamStarted) {
@@ -193,10 +219,6 @@ export class AudioRecorder extends EventEmitter {
 				shouldRetry: (err) => hasErrorCode(err, "DEVICE_BUSY"),
 			},
 		);
-
-		this.setupTimers();
-		logger.info({ device: config.behavior.audioDevice }, "Recording started");
-		this.emit("start");
 	}
 
 	private setupTimers() {
@@ -290,6 +312,7 @@ export class AudioRecorder extends EventEmitter {
 	}
 
 	private async cleanupRecording(): Promise<void> {
+		this.cleanupTimers();
 		if (this.recording) {
 			try {
 				// Wait for the process to actually exit before continuing

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { convertAudio } from "../audio/converter";
 import {
+	assertAudioBackendAvailable,
 	type AudioLevelPayload,
 	AudioRecorder,
 	type PcmAudioPayload,
@@ -401,6 +402,7 @@ export class DaemonService {
 
 	public async start() {
 		try {
+			assertAudioBackendAvailable();
 			await writeFile(this.pidFile, process.pid.toString());
 			await this.ipcServer.start();
 			this.updateState();

--- a/tests/recorder.test.ts
+++ b/tests/recorder.test.ts
@@ -1,0 +1,71 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import {
+	AudioRecorder,
+	assertAudioBackendAvailable,
+} from "../src/audio/recorder";
+import type { Config } from "../src/config/schema";
+
+function createTestConfig(): Config {
+	return {
+		behavior: {
+			audioDevice: "default",
+			clipboard: {
+				minDuration: 0,
+				maxDuration: 1,
+			},
+		},
+	} as Config;
+}
+
+describe("assertAudioBackendAvailable", () => {
+	it("passes when the backend probe succeeds", () => {
+		expect(() => assertAudioBackendAvailable(() => {})).not.toThrow();
+	});
+
+	it("throws a clear audio backend error when the probe fails", () => {
+		expect(() =>
+			assertAudioBackendAvailable(() => {
+				throw new Error("missing");
+			}),
+		).toThrow("Audio recording backend 'arecord' is not installed or not in PATH.");
+	});
+});
+
+describe("AudioRecorder", () => {
+	it("emits start as soon as arecord is spawned, before first audio data", async () => {
+		const stream = new EventEmitter();
+		const process = new EventEmitter() as EventEmitter & {
+			stderr: EventEmitter;
+		};
+		process.stderr = new EventEmitter();
+		const events: string[] = [];
+
+		const recorder = new AudioRecorder({
+			loadConfigFn: () => createTestConfig(),
+			createRecording: () =>
+				({
+					process,
+					stream: () => stream,
+					stop: () => {
+						process.emit("close");
+					},
+				}) as never,
+		});
+
+		recorder.on("start", () => events.push("start"));
+		recorder.on("data", () => events.push("data"));
+
+		const startPromise = recorder.start();
+		await Promise.resolve();
+
+		expect(events).toEqual(["start"]);
+
+		stream.emit("data", Buffer.from("RIFF"));
+		await startPromise;
+
+		expect(events).toEqual(["start", "data"]);
+
+		await recorder.stop(true);
+	});
+});


### PR DESCRIPTION
Closes #46

## Summary
- move the `arecord --version` capability probe to daemon startup before PID/IPC setup
- remove the backend probe from `AudioRecorder.start()` so trigger handling no longer pays that synchronous cost
- emit the recorder `start` event immediately after the arecord process is spawned, before waiting for first audio data
- add recorder seam tests for backend probe pass/fail and start-before-data behavior

## Verification
- bun run tsc --noEmit
- bun test
- bun x npm pack