### PR TITLE
fix: drive stats health from 24h latency

### DIFF
--- a/src/stats/format.ts
+++ b/src/stats/format.ts
@@ -36,7 +36,7 @@ export function formatStatsSummary(summary: StatsSummary): string {
 		colors.cyan("============="),
 		"",
 		`${colors.bold("Today")} ${summary.counts.today}  ${colors.bold("Total")} ${summary.counts.total}  ${colors.bold("History")} ${summary.counts.history}`,
-		`${colors.bold("Latency")} median ${formatMs(summary.latency.medianMs)}  p95 ${formatMs(summary.latency.p95Ms)}  avg ${formatMs(summary.latency.averageMs)}`,
+		`${colors.bold("Latency")} 24h median ${formatMs(summary.latency.medianMs)}  24h p95 ${formatMs(summary.latency.p95Ms)}  24h avg ${formatMs(summary.latency.averageMs)}  lifetime p95 ${formatMs(summary.latency.lifetimeP95Ms)}`,
 		`${colors.bold("Duration")} avg ${formatSeconds(summary.duration.averageSeconds)}  short ${summary.duration.shortCount}  medium ${summary.duration.mediumCount}  long ${summary.duration.longCount}`,
 		`${colors.bold("Daemon")} ${summary.daemon.status}${summary.daemon.pid ? ` (${summary.daemon.pid})` : ""}`,
 		`${colors.bold("Errors")} ${summary.errors.count}${summary.errors.latest ? `  latest: ${summary.errors.latest}` : ""}`,

--- a/src/stats/summary.ts
+++ b/src/stats/summary.ts
@@ -25,6 +25,7 @@ export interface StatsSummary {
 		medianMs: number | null;
 		p95Ms: number | null;
 		averageMs: number | null;
+		lifetimeP95Ms: number | null;
 	};
 	duration: {
 		averageSeconds: number | null;
@@ -526,7 +527,7 @@ export function buildStatsSummaryFromInput(
 	const nowMs = now.getTime();
 	const thresholds = input.thresholds ?? DEFAULT_THRESHOLDS;
 
-	const processingTimes = input.history
+	const lifetimeProcessingTimes = input.history
 		.map((item) => item.processingTime)
 		.filter((value) => Number.isFinite(value) && value >= 0);
 	const durations = input.history
@@ -594,10 +595,10 @@ export function buildStatsSummaryFromInput(
 	}
 
 	const regressionFlags: string[] = [];
-	const p95 = percentile(
-		events24h.map((event) => event.processingMs),
-		95,
-	);
+	const processingTimes24h = events24h
+		.map((event) => event.processingMs)
+		.filter((value) => Number.isFinite(value) && value >= 0);
+	const p95 = percentile(processingTimes24h, 95);
 	const baselineP95 = percentile(
 		eventsInWindow(baseline7d, nowMs - 24 * 3600_000, 6 * 24 * 3600_000).map(
 			(event) => event.processingMs,
@@ -639,9 +640,10 @@ export function buildStatsSummaryFromInput(
 			history: input.history.length,
 		},
 		latency: {
-			medianMs: percentile(processingTimes, 50),
-			p95Ms: percentile(processingTimes, 95),
-			averageMs: average(processingTimes),
+			medianMs: percentile(processingTimes24h, 50),
+			p95Ms: p95,
+			averageMs: average(processingTimes24h),
+			lifetimeP95Ms: percentile(lifetimeProcessingTimes, 95),
 		},
 		duration: {
 			averageSeconds: average(durationSeconds),

--- a/src/stats/tui-io.ts
+++ b/src/stats/tui-io.ts
@@ -6,7 +6,7 @@ import { loadConfig } from "../config/loader";
 import type { StatsSummary } from "./summary";
 import {
 	ms,
-	overallP0,
+	overallHealth,
 	type StatsTab,
 	type StatsWindowPreset,
 } from "./tui-model";
@@ -33,8 +33,9 @@ export async function exportSnapshot(
 			"# Hyprvox Stats Snapshot",
 			`Generated: ${summary.generatedAt}`,
 			`Scope: ${scope} (${tab})`,
-			`P0: ${overallP0(summary)}`,
-			`Latency p95: ${ms(summary.latency.p95Ms)}`,
+			`Health: ${overallHealth(summary)}`,
+			`Latency 24h p95: ${ms(summary.latency.p95Ms)}`,
+			`Latency lifetime p95: ${ms(summary.latency.lifetimeP95Ms)}`,
 			`Errors: ${summary.errors.count}`,
 			`Quality failures 24h: ${summary.quality.total24h}`,
 			`Regression flags: ${summary.regression.flags.join(", ") || "none"}`,

--- a/src/stats/tui-model.ts
+++ b/src/stats/tui-model.ts
@@ -97,7 +97,7 @@ export function recentLatencySparkline(summary: StatsSummary, width: number): st
 	);
 }
 
-export function overallP0(summary: StatsSummary): HealthState {
+export function overallHealth(summary: StatsSummary): HealthState {
 	const latency = latencyState(
 		summary.latency.p95Ms,
 		summary.thresholds.latencyP95WarnMs,

--- a/src/stats/tui-view.tsx
+++ b/src/stats/tui-view.tsx
@@ -12,7 +12,7 @@ import {
 	errorState,
 	latencyState,
 	ms,
-	overallP0,
+	overallHealth,
 	percentile,
 	qualityState,
 	recentLatencySparkline,
@@ -159,7 +159,7 @@ export function StatsDashboardView({
 	recentFilterPrompt,
 	statusMessage,
 }: StatsDashboardViewProps) {
-	const p0 = overallP0(summary);
+	const health = overallHealth(summary);
 	const anomalies = detectAnomalies(summary);
 	const latencyHealth = latencyState(
 		summary.latency.p95Ms,
@@ -236,7 +236,7 @@ export function StatsDashboardView({
 	const topAnomaly = anomalies[0]?.message ?? "none";
 	const kpiRows = [
 		{
-			label: "latency p95",
+			label: "latency 24h p95",
 			value: ms(latency24h),
 			delta: `${latencyTrend} ${latencyDelta}`,
 			confidence: confidenceFromSample(
@@ -288,7 +288,8 @@ export function StatsDashboardView({
 				justifyContent="space-between"
 			>
 				<text fg={colors.text} attributes={TextAttributes.BOLD}>
-					hyprvox stats | p0 {p0} | {tabLabel(activeTab)} | filter {filter}
+					hyprvox stats | Health {health} | {tabLabel(activeTab)} | filter{" "}
+					{filter}
 				</text>
 				<text fg={colors.muted}>
 					{autoRefresh ? "auto:on" : "auto:off"} | ttfp {ttfpMs ?? 0}ms | upd{" "}
@@ -301,7 +302,7 @@ export function StatsDashboardView({
 					daemon {summary.daemon.status}
 				</text>
 				<text fg={stateColor(latencyHealth)}>
-					p95 {ms(summary.latency.p95Ms)}
+					24h p95 {ms(summary.latency.p95Ms)}
 				</text>
 				<text fg={stateColor(errorHealth)}>errors {summary.errors.count}</text>
 				<text fg={stateColor(qualityHealth)}>

--- a/tests/stats-summary.test.ts
+++ b/tests/stats-summary.test.ts
@@ -67,8 +67,10 @@ describe("stats summary", () => {
 		});
 
 		expect(summary.counts).toEqual({ today: 2, total: 10, history: 3 });
-		expect(summary.latency.medianMs).toBe(2000);
-		expect(summary.latency.p95Ms).toBe(5000);
+		expect(summary.latency.medianMs).toBe(1800);
+		expect(summary.latency.p95Ms).toBe(1800);
+		expect(summary.latency.averageMs).toBe(1800);
+		expect(summary.latency.lifetimeP95Ms).toBe(5000);
 		expect(summary.duration.averageSeconds).toBeCloseTo(52.67, 2);
 		expect(summary.duration.shortCount).toBe(1);
 		expect(summary.duration.mediumCount).toBe(1);
@@ -136,5 +138,53 @@ describe("stats summary", () => {
 
 		expect(summary.regression.flags).not.toContain("latency_p95_regressed");
 		expect(summary.cache.eventLagMs).toBe(28 * 60 * 60 * 1000);
+	});
+
+	test("uses 24h perf latency for health inputs while retaining lifetime p95", () => {
+		const summary = buildStatsSummaryFromInput({
+			stats: { today: 2, total: 10 },
+			history: [
+				...history,
+				{
+					timestamp: "2026-05-20T10:00:00.000Z",
+					text: "historical slow item",
+					duration: 8,
+					engine: "groq",
+					processingTime: 9000,
+				},
+			],
+			daemon: { running: true, status: "idle", pid: 123 },
+			errors: { count: 0, latest: null, recent: [] },
+			paths: {
+				config: "/config.json",
+				history: "/history.json",
+				logs: "/logs",
+			},
+			now: new Date("2026-05-23T12:00:00.000Z"),
+			perfEvents: [
+				{
+					timestamp: "2026-05-23T11:30:00.000Z",
+					processingMs: 1400,
+					mergeStrategy: "exact_match",
+					mergeReason: "sources_match",
+					validationReasons: [],
+					validationRetryCount: 0,
+					validationFallbackSource: "none",
+				},
+				{
+					timestamp: "2026-05-22T06:00:00.000Z",
+					processingMs: 8000,
+					mergeStrategy: "llm",
+					mergeReason: "llm_succeeded",
+					validationReasons: [],
+					validationRetryCount: 0,
+					validationFallbackSource: "none",
+				},
+			],
+		});
+
+		expect(summary.latency.p95Ms).toBe(1400);
+		expect(summary.latency.lifetimeP95Ms).toBe(9000);
+		expect(summary.trends.processingMs.window24h).toEqual([1400]);
 	});
 });

--- a/tests/stats-tui-model.test.ts
+++ b/tests/stats-tui-model.test.ts
@@ -11,7 +11,7 @@ import {
 	ms,
 	nextFilter,
 	nextTab,
-	overallP0,
+	overallHealth,
 	prevTab,
 	qualityState,
 	recentLatencySparkline,
@@ -25,7 +25,7 @@ import {
 const baseSummary: StatsSummary = {
 	generatedAt: "2026-05-25T10:00:00.000Z",
 	counts: { today: 1, total: 10, history: 4 },
-	latency: { medianMs: 1100, p95Ms: 4200, averageMs: 1800 },
+	latency: { medianMs: 1100, p95Ms: 4200, averageMs: 1800, lifetimeP95Ms: 4200 },
 	duration: { averageSeconds: 12.4, shortCount: 3, mediumCount: 1, longCount: 0 },
 	engines: { "groq+deepgram": 3, groq: 1 },
 	recent: [
@@ -156,8 +156,8 @@ describe("stats tui model helpers", () => {
 		expect(daemonState("stopped")).toBe("BAD");
 	});
 
-	it("computes P0 state from summary", () => {
-		expect(overallP0(baseSummary)).toBe("BAD");
+	it("computes Health state from summary", () => {
+		expect(overallHealth(baseSummary)).toBe("BAD");
 	});
 
 	it("cycles filter order", () => {

--- a/tests/stats-tui-recent.test.ts
+++ b/tests/stats-tui-recent.test.ts
@@ -5,7 +5,7 @@ import type { StatsSummary } from "../src/stats/summary";
 const summary: StatsSummary = {
 	generatedAt: "2026-05-25T10:00:00.000Z",
 	counts: { today: 1, total: 10, history: 2 },
-	latency: { medianMs: 1100, p95Ms: 4200, averageMs: 1800 },
+	latency: { medianMs: 1100, p95Ms: 4200, averageMs: 1800, lifetimeP95Ms: 4200 },
 	duration: { averageSeconds: 12.4, shortCount: 2, mediumCount: 0, longCount: 0 },
 	engines: { "groq+deepgram": 2 },
 	recent: [


### PR DESCRIPTION
Closes #47

## Summary
- make `summary.latency.*` use the trailing 24h perf-event latency window
- retain all-time history p95 as explicit `lifetimeP95Ms` in the plain/export summaries
- rename user-facing `p0`/`P0` labels to `Health`
- keep overview/header latency aligned on the same 24h source

## Verification
- bun run tsc --noEmit
- bun test
- bun x npm pack