### PR TITLE
fix: remove fake stats cache hit rate

### DIFF
--- a/src/stats/summary.ts
+++ b/src/stats/summary.ts
@@ -101,7 +101,6 @@ export interface StatsSummary {
 	cache: {
 		source: "aggregate" | "logs";
 		lastRebuildAt: string;
-		hitRate: number;
 		eventLagMs: number;
 	};
 	trends: {
@@ -130,7 +129,6 @@ export interface StatsSummaryInput {
 	cacheMeta?: {
 		source: "aggregate" | "logs";
 		lastRebuildAt: string;
-		hitRate: number;
 	};
 	now?: Date;
 }
@@ -270,7 +268,6 @@ async function loadPerfEventsHybrid(
 	events: PerfEvent[];
 	source: "aggregate" | "logs";
 	lastRebuildAt: string;
-	hitRate: number;
 }> {
 	const now = Date.now();
 	if (!forceRefresh && perfEventCache && perfEventCache.expiresAt > now) {
@@ -278,7 +275,6 @@ async function loadPerfEventsHybrid(
 			events: perfEventCache.events,
 			source: perfEventCache.source,
 			lastRebuildAt: perfEventCache.lastRebuildAt,
-			hitRate: 1,
 		};
 	}
 
@@ -295,7 +291,6 @@ async function loadPerfEventsHybrid(
 			events,
 			source: "aggregate",
 			lastRebuildAt: perfEventCache.lastRebuildAt,
-			hitRate: 0.95,
 		};
 	}
 
@@ -310,7 +305,6 @@ async function loadPerfEventsHybrid(
 		events,
 		source: "logs",
 		lastRebuildAt: perfEventCache.lastRebuildAt,
-		hitRate: 0.3,
 	};
 }
 
@@ -515,7 +509,6 @@ export async function buildStatsSummaryWithOptions(
 		cacheMeta: {
 			source: perfBundle.source,
 			lastRebuildAt: perfBundle.lastRebuildAt,
-			hitRate: perfBundle.hitRate,
 		},
 	});
 }
@@ -701,7 +694,6 @@ export function buildStatsSummaryFromInput(
 			cache: {
 				source: input.cacheMeta?.source ?? "logs",
 				lastRebuildAt: input.cacheMeta?.lastRebuildAt ?? now.toISOString(),
-				hitRate: input.cacheMeta?.hitRate ?? 0,
 				eventLagMs: Math.max(
 					0,
 					nowMs -

--- a/src/stats/tui-view.tsx
+++ b/src/stats/tui-view.tsx
@@ -459,9 +459,7 @@ export function StatsDashboardView({
 							{degradedMode ? null : (
 								<Section title="Cache Health" height={8}>
 									<text fg={colors.text}>source {summary.cache.source}</text>
-									<text fg={colors.text}>
-										hit-rate {(summary.cache.hitRate * 100).toFixed(0)}%
-									</text>
+									<text fg={freshnessColor}>freshness {freshness}</text>
 									<text fg={colors.text}>
 										event lag {ms(summary.cache.eventLagMs)}
 									</text>

--- a/tests/stats-summary.test.ts
+++ b/tests/stats-summary.test.ts
@@ -86,6 +86,7 @@ describe("stats summary", () => {
 		expect(summary.pipeline.validationRetries24h).toBe(1);
 		expect(summary.regression.window24hCount).toBe(1);
 		expect(summary.cache.source).toBe("logs");
+		expect(summary.cache).not.toHaveProperty("hitRate");
 	});
 
 	test("uses 24h-scoped errors, baseline-aware latency regression, and newest-event lag", () => {
@@ -132,7 +133,6 @@ describe("stats summary", () => {
 			cacheMeta: {
 				source: "aggregate",
 				lastRebuildAt: "2026-05-23T11:59:00.000Z",
-				hitRate: 0.95,
 			},
 		});
 

--- a/tests/stats-tui-model.test.ts
+++ b/tests/stats-tui-model.test.ts
@@ -105,7 +105,6 @@ const baseSummary: StatsSummary = {
 	cache: {
 		source: "aggregate",
 		lastRebuildAt: "2026-05-25T10:00:00.000Z",
-		hitRate: 0.95,
 		eventLagMs: 1200,
 	},
 	trends: {

--- a/tests/stats-tui-recent.test.ts
+++ b/tests/stats-tui-recent.test.ts
@@ -72,7 +72,6 @@ const summary: StatsSummary = {
 	cache: {
 		source: "aggregate",
 		lastRebuildAt: "2026-05-25T10:00:00.000Z",
-		hitRate: 0.95,
 		eventLagMs: 1200,
 	},
 	trends: {


### PR DESCRIPTION
Closes #48

## Summary
- remove the fabricated cache hit-rate from the stats summary contract and cache loading path
- replace the cache panel hit-rate row with freshness derived from event lag
- keep source, event lag, and last rebuild as the honest cache signals

## Verification
- bun run tsc --noEmit
- bun test
- bun x npm pack