### PR TITLE
fix: make stats trends honest

### DIFF
--- a/src/stats/summary.ts
+++ b/src/stats/summary.ts
@@ -76,6 +76,7 @@ export interface StatsSummary {
 	quality: {
 		window24h: Record<QualityReason, number>;
 		total24h: number;
+		baseline24hAverage: number | null;
 		spike: boolean;
 	};
 	pipeline: {
@@ -565,6 +566,17 @@ export function buildStatsSummaryFromInput(
 		(sum, count) => sum + count,
 		0,
 	);
+	const prior6dEvents = eventsInWindow(
+		baseline7d,
+		nowMs - 24 * 3600_000,
+		6 * 24 * 3600_000,
+	);
+	const prior6dQualityTotal = prior6dEvents.reduce(
+		(sum, event) => sum + event.validationReasons.length,
+		0,
+	);
+	const qualityBaseline24hAverage =
+		prior6dEvents.length > 0 ? prior6dQualityTotal / 6 : null;
 
 	const mergeStrategies24h: Record<string, number> = {};
 	const fallbacks24h: Record<"none" | "groq" | "deepgram", number> = {
@@ -676,6 +688,7 @@ export function buildStatsSummaryFromInput(
 		quality: {
 			window24h: qualityWindow24h,
 			total24h: qualityTotal24h,
+			baseline24hAverage: qualityBaseline24hAverage,
 			spike,
 		},
 		pipeline: {

--- a/src/stats/tui-model.ts
+++ b/src/stats/tui-model.ts
@@ -9,6 +9,11 @@ export type Anomaly = {
 	severity: "warn" | "bad";
 	message: string;
 };
+export type TrendDelta = {
+	arrow: string;
+	delta: string;
+	text: string;
+};
 
 export function ms(value: number | null): string {
 	return value === null ? "n/a" : `${Math.round(value)}ms`;
@@ -231,6 +236,26 @@ export function deltaPercent(current: number | null, baseline: number | null): s
 
 export function confidenceFromSample(sampleSize: number, minSampleSize: number): "high" | "low" {
 	return sampleSize >= minSampleSize ? "high" : "low";
+}
+
+export function latencyTrendDelta(summary: StatsSummary): TrendDelta {
+	const current = percentile(summary.trends.processingMs.window24h, 95);
+	const baseline = percentile(summary.trends.processingMs.window7d, 95);
+	const arrow = trendArrow(current, baseline);
+	const delta = deltaPercent(current, baseline);
+	return { arrow, delta, text: `${arrow} ${delta}` };
+}
+
+export function qualityTrendDelta(summary: StatsSummary): TrendDelta {
+	const current = summary.quality.total24h;
+	const baseline = summary.quality.baseline24hAverage;
+	const arrow = trendArrow(current, baseline);
+	const delta = deltaPercent(current, baseline);
+	return { arrow, delta, text: `${arrow} ${delta}` };
+}
+
+export function errorThresholdDelta(summary: StatsSummary): string {
+	return `threshold ${summary.thresholds.errorWarnCount24h}/${summary.thresholds.errorBadCount24h}`;
 }
 
 export function runtimeActionHint(summary: StatsSummary, anomalies: Anomaly[]): string {

--- a/src/stats/tui-view.tsx
+++ b/src/stats/tui-view.tsx
@@ -7,13 +7,15 @@ import {
 	confidenceFromSample,
 	confidenceLabel,
 	daemonState,
-	deltaPercent,
 	detectAnomalies,
+	errorThresholdDelta,
 	errorState,
+	latencyTrendDelta,
 	latencyState,
 	ms,
 	overallHealth,
 	percentile,
+	qualityTrendDelta,
 	qualityState,
 	recentLatencySparkline,
 	runtimeActionHint,
@@ -195,23 +197,10 @@ export function StatsDashboardView({
 	const windowSpark = sparkline(windowValues, 36);
 	const recentLatencySpark = recentLatencySparkline(summary, 24);
 	const latency24h = percentile(summary.trends.processingMs.window24h, 95);
-	const latency7d = percentile(summary.trends.processingMs.window7d, 95);
-	const latencyTrend = trendArrow(latency24h, latency7d);
-	const latencyDelta = deltaPercent(latency24h, latency7d);
+	const latencyTrend = latencyTrendDelta(summary);
 	const error24h = summary.errors.count;
-	const baselineErrors24h = Math.max(
-		1,
-		Math.round((summary.regression.baseline7dCount / 7) * 0.03),
-	);
-	const errorTrend = trendArrow(error24h, baselineErrors24h);
-	const errorDelta = deltaPercent(error24h, baselineErrors24h);
 	const quality24h = summary.quality.total24h;
-	const baselineQuality24h = Math.max(
-		1,
-		Math.round((summary.regression.baseline7dCount / 7) * 0.01),
-	);
-	const qualityTrend = trendArrow(quality24h, baselineQuality24h);
-	const qualityDelta = deltaPercent(quality24h, baselineQuality24h);
+	const qualityTrend = qualityTrendDelta(summary);
 	const throughputPerHour = summary.regression.window1hCount;
 	const throughputBaselinePerHour = Math.max(
 		1,
@@ -238,7 +227,7 @@ export function StatsDashboardView({
 		{
 			label: "latency 24h p95",
 			value: ms(latency24h),
-			delta: `${latencyTrend} ${latencyDelta}`,
+			delta: latencyTrend.text,
 			confidence: confidenceFromSample(
 				summary.trends.processingMs.window24h.length,
 				minSampleSize,
@@ -250,7 +239,7 @@ export function StatsDashboardView({
 		{
 			label: "errors 24h",
 			value: String(error24h),
-			delta: `${errorTrend} ${errorDelta}`,
+			delta: errorThresholdDelta(summary),
 			confidence: confidenceFromSample(
 				summary.regression.window24hCount,
 				minSampleSize,
@@ -261,7 +250,7 @@ export function StatsDashboardView({
 		{
 			label: "quality 24h",
 			value: String(quality24h),
-			delta: `${qualityTrend} ${qualityDelta}`,
+			delta: qualityTrend.text,
 			confidence: confidenceFromSample(
 				summary.regression.window24hCount,
 				minSampleSize,

--- a/tests/stats-summary.test.ts
+++ b/tests/stats-summary.test.ts
@@ -80,6 +80,7 @@ describe("stats summary", () => {
 		expect(summary.errors.recent).toEqual([]);
 		expect(summary.health.overall).toBe("PASS");
 		expect(summary.quality.total24h).toBe(1);
+		expect(summary.quality.baseline24hAverage).toBeNull();
 		expect(summary.quality.window24h.token_injection).toBe(1);
 		expect(summary.pipeline.mergeStrategies24h.llm).toBe(1);
 		expect(summary.pipeline.modelRank24h["llama-3.3-70b-versatile"]).toBe(1);
@@ -137,7 +138,55 @@ describe("stats summary", () => {
 		});
 
 		expect(summary.regression.flags).not.toContain("latency_p95_regressed");
+		expect(summary.quality.baseline24hAverage).toBe(0);
 		expect(summary.cache.eventLagMs).toBe(28 * 60 * 60 * 1000);
+	});
+
+	test("computes quality trend baseline from prior six days of perf events", () => {
+		const summary = buildStatsSummaryFromInput({
+			stats: { today: 2, total: 10 },
+			history,
+			daemon: { running: true, status: "idle", pid: 123 },
+			errors: { count: 0, latest: null, recent: [] },
+			paths: {
+				config: "/config.json",
+				history: "/history.json",
+				logs: "/logs",
+			},
+			now: new Date("2026-05-23T12:00:00.000Z"),
+			perfEvents: [
+				{
+					timestamp: "2026-05-23T11:30:00.000Z",
+					processingMs: 1400,
+					mergeStrategy: "exact_match",
+					mergeReason: "sources_match",
+					validationReasons: ["token_injection", "mixed_script"],
+					validationRetryCount: 0,
+					validationFallbackSource: "none",
+				},
+				{
+					timestamp: "2026-05-22T11:30:00.000Z",
+					processingMs: 1500,
+					mergeStrategy: "llm",
+					mergeReason: "llm_succeeded",
+					validationReasons: ["prompt_artifact"],
+					validationRetryCount: 0,
+					validationFallbackSource: "none",
+				},
+				{
+					timestamp: "2026-05-21T11:30:00.000Z",
+					processingMs: 1600,
+					mergeStrategy: "llm",
+					mergeReason: "llm_succeeded",
+					validationReasons: ["cot_meta", "garbage"],
+					validationRetryCount: 0,
+					validationFallbackSource: "none",
+				},
+			],
+		});
+
+		expect(summary.quality.total24h).toBe(2);
+		expect(summary.quality.baseline24hAverage).toBe(0.5);
 	});
 
 	test("uses 24h perf latency for health inputs while retaining lifetime p95", () => {

--- a/tests/stats-tui-model.test.ts
+++ b/tests/stats-tui-model.test.ts
@@ -6,13 +6,16 @@ import {
 	daemonState,
 	detectAnomalies,
 	deltaPercent,
+	errorThresholdDelta,
 	errorState,
+	latencyTrendDelta,
 	latencyState,
 	ms,
 	nextFilter,
 	nextTab,
 	overallHealth,
 	prevTab,
+	qualityTrendDelta,
 	qualityState,
 	recentLatencySparkline,
 	runtimeActionHint,
@@ -80,6 +83,7 @@ const baseSummary: StatsSummary = {
 			garbage: 0,
 		},
 		total24h: 1,
+		baseline24hAverage: 0.5,
 		spike: false,
 	},
 	pipeline: {
@@ -215,6 +219,66 @@ describe("stats tui model helpers", () => {
 		expect(trendArrow(104, 100)).toBe("~");
 		expect(deltaPercent(120, 100)).toBe("+20%");
 		expect(deltaPercent(80, 100)).toBe("-20%");
+	});
+
+	it("compares latency trend from 24h p95 against 7d p95", () => {
+		const summary: StatsSummary = {
+			...baseSummary,
+			trends: {
+				processingMs: {
+					...baseSummary.trends.processingMs,
+					window24h: [1000, 2000, 4500],
+					window7d: [1000, 2000, 3000],
+				},
+			},
+		};
+
+		expect(latencyTrendDelta(summary)).toEqual({
+			arrow: "↑",
+			delta: "+50%",
+			text: "↑ +50%",
+		});
+	});
+
+	it("compares quality trend against real recent quality baseline", () => {
+		const summary: StatsSummary = {
+			...baseSummary,
+			quality: {
+				...baseSummary.quality,
+				total24h: 4,
+				baseline24hAverage: 2,
+			},
+		};
+
+		expect(qualityTrendDelta(summary)).toEqual({
+			arrow: "↑",
+			delta: "+100%",
+			text: "↑ +100%",
+		});
+	});
+
+	it("shows unknown quality trend when no real baseline exists", () => {
+		const summary: StatsSummary = {
+			...baseSummary,
+			quality: {
+				...baseSummary.quality,
+				total24h: 4,
+				baseline24hAverage: null,
+			},
+		};
+
+		expect(qualityTrendDelta(summary)).toEqual({
+			arrow: "~",
+			delta: "n/a",
+			text: "~ n/a",
+		});
+	});
+
+	it("formats errors as absolute count against threshold without a trend", () => {
+		const delta = errorThresholdDelta(baseSummary);
+
+		expect(delta).toBe("threshold 5/20");
+		expect(delta).not.toMatch(/[↑↓+%]/u);
 	});
 
 	it("provides runtime action hint from anomaly priority", () => {

--- a/tests/stats-tui-recent.test.ts
+++ b/tests/stats-tui-recent.test.ts
@@ -47,6 +47,7 @@ const summary: StatsSummary = {
 			garbage: 0,
 		},
 		total24h: 1,
+		baseline24hAverage: 0.5,
 		spike: false,
 	},
 	pipeline: {


### PR DESCRIPTION
Closes #49

## Summary
- compute quality trend from real validation-reason baseline over prior perf events
- remove fabricated error trend arrow/delta and show errors against thresholds
- preserve latency 24h-vs-7d trend behavior

## Verification
- bun run tsc --noEmit
- bun test
- bun x npm pack