### PR TITLE
fix: normalize history duration units

### DIFF
--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -1128,12 +1128,13 @@ export class DaemonService {
 						? "groq"
 						: "deepgram";
 			metrics.engine = engineUsed;
+			const recordingDurationSeconds = duration / 1000;
 
 			const historyTimed = await timeAsync(() =>
 				appendHistory({
 					timestamp: new Date().toISOString(),
 					text: finalText,
-					duration,
+					duration: recordingDurationSeconds,
 					engine: engineUsed,
 					processingTime,
 					groqSttModel: metrics.groqSttModel,

--- a/src/stats/summary.ts
+++ b/src/stats/summary.ts
@@ -159,10 +159,6 @@ function average(values: number[]): number | null {
 	return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
-function normalizeDurationSeconds(value: number): number {
-	return value > 3600 ? value / 1000 : value;
-}
-
 function readDaemonState(): StatsSummary["daemon"] {
 	const configDir = join(homedir(), ".config", "hypr", "vox");
 	const pidFile = join(configDir, "daemon.pid");
@@ -527,7 +523,6 @@ export function buildStatsSummaryFromInput(
 	const durations = input.history
 		.map((item) => item.duration)
 		.filter((value) => Number.isFinite(value) && value >= 0);
-	const durationSeconds = durations.map(normalizeDurationSeconds);
 	const engines = input.history.reduce<Record<string, number>>((acc, item) => {
 		acc[item.engine || "unknown"] = (acc[item.engine || "unknown"] ?? 0) + 1;
 		return acc;
@@ -651,12 +646,12 @@ export function buildStatsSummaryFromInput(
 			lifetimeP95Ms: percentile(lifetimeProcessingTimes, 95),
 		},
 		duration: {
-			averageSeconds: average(durationSeconds),
-			shortCount: durationSeconds.filter((duration) => duration < 15).length,
-			mediumCount: durationSeconds.filter(
+			averageSeconds: average(durations),
+			shortCount: durations.filter((duration) => duration < 15).length,
+			mediumCount: durations.filter(
 				(duration) => duration >= 15 && duration < 60,
 			).length,
-			longCount: durationSeconds.filter((duration) => duration >= 60).length,
+			longCount: durations.filter((duration) => duration >= 60).length,
 		},
 		engines,
 		recent: input.history.slice(-12).reverse(),

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -25,6 +25,41 @@ export interface SearchOptions {
 	to?: string;
 }
 
+const MAX_CONFIGURED_RECORDING_SECONDS = 600;
+
+function normalizeHistoryDurationSeconds(duration: number): number {
+	if (!Number.isFinite(duration) || duration < 0) return duration;
+	return duration > MAX_CONFIGURED_RECORDING_SECONDS ? duration / 1000 : duration;
+}
+
+function normalizeHistoryItem(item: HistoryItem): HistoryItem {
+	const duration = normalizeHistoryDurationSeconds(item.duration);
+	return duration === item.duration ? item : { ...item, duration };
+}
+
+function normalizeHistoryItems(history: HistoryItem[]): {
+	history: HistoryItem[];
+	changed: boolean;
+} {
+	if (
+		!history.some(
+			(item) =>
+				Number.isFinite(item.duration) &&
+				item.duration > MAX_CONFIGURED_RECORDING_SECONDS,
+		)
+	) {
+		return { history, changed: false };
+	}
+
+	let changed = false;
+	const normalized = history.map((item) => {
+		const next = normalizeHistoryItem(item);
+		if (next !== item) changed = true;
+		return next;
+	});
+	return { history: normalized, changed };
+}
+
 export async function searchHistory(
 	options: SearchOptions,
 ): Promise<HistoryItem[]> {
@@ -89,13 +124,13 @@ export async function appendHistory(item: HistoryItem): Promise<void> {
 		if (existsSync(historyFile)) {
 			const loaded = await readJsonFile<HistoryItem[]>(historyFile);
 			if (Array.isArray(loaded)) {
-				history = loaded;
+				history = normalizeHistoryItems(loaded).history;
 			} else if (loaded !== null) {
 				logger.warn("History file format invalid, resetting to empty array");
 			}
 		}
 
-		history.push(item);
+		history.push(normalizeHistoryItem(item));
 
 		if (history.length > 1000) {
 			history = history.slice(-1000);
@@ -124,7 +159,17 @@ export async function loadHistory(): Promise<HistoryItem[]> {
 
 	try {
 		const history = await readJsonFile<HistoryItem[]>(historyFile);
-		return Array.isArray(history) ? history : [];
+		if (!Array.isArray(history)) return [];
+
+		const normalized = normalizeHistoryItems(history);
+		if (normalized.changed) {
+			await atomicWriteFile(
+				historyFile,
+				JSON.stringify(normalized.history, null, 2),
+				{ mode: 0o600 },
+			);
+		}
+		return normalized.history;
 	} catch (error) {
 		logger.error({ error, historyFile }, "Failed to load history");
 		return [];

--- a/tests/integration/history_storage.test.ts
+++ b/tests/integration/history_storage.test.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -96,6 +103,54 @@ describe("History Storage Integration", () => {
 
 		expect(existsSync(nestedFile)).toBe(true);
 		expect(await loadHistory()).toHaveLength(1);
+	});
+
+	it("should migrate legacy millisecond durations to seconds on load", async () => {
+		const legacyItems: HistoryItem[] = [
+			{
+				timestamp: new Date().toISOString(),
+				text: "Legacy short recording",
+				duration: 2500,
+				engine: "test",
+				processingTime: 100,
+			},
+			{
+				timestamp: new Date().toISOString(),
+				text: "Legacy long recording",
+				duration: 120000,
+				engine: "test",
+				processingTime: 100,
+			},
+		];
+		writeFileSync(HISTORY_FILE, JSON.stringify(legacyItems, null, 2));
+
+		const loaded = await loadHistory();
+		expect(loaded.map((item) => item.duration)).toEqual([2.5, 120]);
+
+		const onDisk = JSON.parse(readFileSync(HISTORY_FILE, "utf-8"));
+		expect(onDisk.map((item: HistoryItem) => item.duration)).toEqual([2.5, 120]);
+	});
+
+	it("should normalize existing legacy durations when appending history", async () => {
+		const legacyItem: HistoryItem = {
+			timestamp: new Date().toISOString(),
+			text: "Legacy append base",
+			duration: 30000,
+			engine: "test",
+			processingTime: 100,
+		};
+		writeFileSync(HISTORY_FILE, JSON.stringify([legacyItem], null, 2));
+
+		await appendHistory({
+			timestamp: new Date().toISOString(),
+			text: "New seconds item",
+			duration: 4.5,
+			engine: "test",
+			processingTime: 100,
+		});
+
+		const loaded = await loadHistory();
+		expect(loaded.map((item) => item.duration)).toEqual([30, 4.5]);
 	});
 
 	it("should enforce the 1000 item limit across multiple appends", async () => {

--- a/tests/stats-summary.test.ts
+++ b/tests/stats-summary.test.ts
@@ -13,14 +13,14 @@ const history: HistoryItem[] = [
 	{
 		timestamp: "2026-05-23T10:01:00.000Z",
 		text: "medium",
-		duration: 30_000,
+		duration: 30,
 		engine: "groq+deepgram",
 		processingTime: 2000,
 	},
 	{
 		timestamp: "2026-05-23T10:02:00.000Z",
 		text: "long",
-		duration: 120_000,
+		duration: 120,
 		engine: "groq+deepgram",
 		processingTime: 5000,
 	},
@@ -235,5 +235,48 @@ describe("stats summary", () => {
 		expect(summary.latency.p95Ms).toBe(1400);
 		expect(summary.latency.lifetimeP95Ms).toBe(9000);
 		expect(summary.trends.processingMs.window24h).toEqual([1400]);
+	});
+
+	test("uses canonical seconds directly for genuine long recording durations", () => {
+		const summary = buildStatsSummaryFromInput({
+			stats: { today: 2, total: 10 },
+			history: [
+				{
+					timestamp: "2026-05-23T10:00:00.000Z",
+					text: "short",
+					duration: 8,
+					engine: "groq",
+					processingTime: 1000,
+				},
+				{
+					timestamp: "2026-05-23T10:01:00.000Z",
+					text: "medium",
+					duration: 45,
+					engine: "groq+deepgram",
+					processingTime: 2000,
+				},
+				{
+					timestamp: "2026-05-23T10:02:00.000Z",
+					text: "over one hour",
+					duration: 7200,
+					engine: "groq+deepgram",
+					processingTime: 5000,
+				},
+			],
+			daemon: { running: true, status: "idle", pid: 123 },
+			errors: { count: 0, latest: null, recent: [] },
+			paths: {
+				config: "/config.json",
+				history: "/history.json",
+				logs: "/logs",
+			},
+			now: new Date("2026-05-23T12:00:00.000Z"),
+			perfEvents: [],
+		});
+
+		expect(summary.duration.averageSeconds).toBeCloseTo(2417.67, 2);
+		expect(summary.duration.shortCount).toBe(1);
+		expect(summary.duration.mediumCount).toBe(1);
+		expect(summary.duration.longCount).toBe(1);
 	});
 });


### PR DESCRIPTION
Closes #50

## Summary
- store new history durations in canonical seconds while keeping transcription metrics in milliseconds
- migrate legacy millisecond history durations to seconds on load/append
- remove the stats read-time duration heuristic and update duration fixtures/tests

## Verification
- bun run tsc --noEmit
- bun test
- bun x npm pack