### PR TITLE
fix: share deepgram key validation

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { Command } from "commander";
 import readlineSync from "readline-sync";
 import * as colors from "yoctocolors";
+import { isValidDeepgramApiKey } from "../config/api-keys";
 import { DEFAULT_CONFIG_FILE, loadConfig } from "../config/loader";
 import { saveConfig } from "../config/writer";
 
@@ -270,9 +271,7 @@ configCommand
 					hideEchoBack: true,
 					mask: "*",
 					validate: (input: string) =>
-						(/^[a-fA-F0-9-]+$/.test(input) &&
-							input.length >= 32 &&
-							input.length <= 40) ||
+						isValidDeepgramApiKey(input) ||
 						colors.red(
 							"Invalid format: Deepgram API key must be a valid UUID or 40-char hex string",
 						),

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -6,6 +6,10 @@ import { Command } from "commander";
 import readlineSync from "readline-sync";
 import * as colors from "yoctocolors";
 import { AudioDeviceService } from "../audio/device-service";
+import {
+	hasConfiguredTranscriptionApiKeys,
+	isValidDeepgramApiKey,
+} from "../config/api-keys";
 import { DEFAULT_CONFIG_FILE, loadConfig } from "../config/loader";
 import type { ConfigFile } from "../config/schema";
 import { saveConfig } from "../config/writer";
@@ -255,14 +259,6 @@ function askOptionalSecret(
 	return askOptionalSecret(prompt, validate);
 }
 
-function hasConfiguredApiKeys(config: ConfigFile): boolean {
-	return Boolean(
-		config.apiKeys?.groq?.startsWith("gsk_") &&
-			typeof config.apiKeys?.deepgram === "string" &&
-			config.apiKeys.deepgram.length >= 32,
-	);
-}
-
 const SETUP_REPORT_FILE = join(
 	homedir(),
 	".config",
@@ -318,8 +314,10 @@ async function collectInteractiveWizardUpdates(
 	const deepgramKey = askOptionalSecret(
 		"\nEnter Deepgram API Key [enter to keep current]: ",
 		(input) =>
-			(input.length >= 32 && input.length <= 40) ||
-			colors.red("Deepgram API key must be 32-40 characters"),
+			isValidDeepgramApiKey(input) ||
+			colors.red(
+				"Deepgram API key must be a 40-character hex string or valid UUID",
+			),
 	);
 
 	if (groqKey || deepgramKey) {
@@ -388,7 +386,7 @@ async function runSetupWizard(
 		);
 		return {
 			nextConfig: workingConfig,
-			apiKeysConfigured: hasConfiguredApiKeys(workingConfig),
+			apiKeysConfigured: hasConfiguredTranscriptionApiKeys(workingConfig),
 		};
 	}
 
@@ -396,7 +394,7 @@ async function runSetupWizard(
 	const nextConfig = mergeConfig(workingConfig, updates);
 	return {
 		nextConfig,
-		apiKeysConfigured: hasConfiguredApiKeys(nextConfig),
+		apiKeysConfigured: hasConfiguredTranscriptionApiKeys(nextConfig),
 	};
 }
 
@@ -443,7 +441,7 @@ async function configureInteractively(options: SetupOptions): Promise<boolean> {
 
 	if (!options.nonInteractive && !askYesNoQuit("Apply these setup changes?")) {
 		console.log(colors.yellow("Setup changes cancelled by user."));
-		return hasConfiguredApiKeys(config);
+		return hasConfiguredTranscriptionApiKeys(config);
 	}
 
 	if (!options.dryRun && changes.length > 0) saveConfig(nextConfig);

--- a/src/config/api-keys.ts
+++ b/src/config/api-keys.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const DeepgramApiKeySchema = z
+	.string()
+	.min(32, { message: "Deepgram API key is too short" })
+	.max(40, { message: "Deepgram API key is too long" })
+	.refine(
+		(value) => {
+			const is40CharHex = /^[a-fA-F0-9]{40}$/.test(value);
+			const isUuid =
+				/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/.test(
+					value,
+				);
+			return is40CharHex || isUuid;
+		},
+		{
+			message:
+				"Deepgram API key must be a 40-character hex string or a valid UUID format",
+		},
+	);
+
+export function isValidDeepgramApiKey(value: unknown): value is string {
+	return DeepgramApiKeySchema.safeParse(value).success;
+}
+
+export function isConfiguredGroqApiKey(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value.startsWith("gsk_") &&
+		value.length >= 10
+	);
+}
+
+export function hasConfiguredTranscriptionApiKeys(config: {
+	apiKeys?: {
+		groq?: unknown;
+		deepgram?: unknown;
+	};
+}): boolean {
+	return (
+		isConfiguredGroqApiKey(config.apiKeys?.groq) &&
+		isValidDeepgramApiKey(config.apiKeys?.deepgram)
+	);
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DeepgramApiKeySchema } from "./api-keys";
 
 /**
  * Custom validator for boost words count.
@@ -223,25 +224,7 @@ export const ApiKeysSchema = z.object({
 		})
 		.min(10, { message: "Fallback Groq API key is too short" })
 		.optional(),
-	deepgram: z
-		.string()
-		.min(32, { message: "Deepgram API key is too short" })
-		.max(40, { message: "Deepgram API key is too long" })
-		.refine(
-			(val) => {
-				// Allow 40-character hex string OR standard UUID format
-				const is40CharHex = /^[a-fA-F0-9]{40}$/.test(val);
-				const isUUID =
-					/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/.test(
-						val,
-					);
-				return is40CharHex || isUUID;
-			},
-			{
-				message:
-					"Deepgram API key must be a 40-character hex string or a valid UUID format",
-			},
-		),
+	deepgram: DeepgramApiKeySchema,
 });
 
 export const ApiKeysFileSchema = ApiKeysSchema.partial().refine(

--- a/src/stats/summary.ts
+++ b/src/stats/summary.ts
@@ -2,6 +2,10 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { AudioDeviceService } from "../audio/device-service";
+import {
+	isConfiguredGroqApiKey,
+	isValidDeepgramApiKey,
+} from "../config/api-keys";
 import { DEFAULT_CONFIG_FILE, loadConfig } from "../config/loader";
 import type { DaemonState } from "../daemon/service";
 import { detectEnvironment } from "../setup/environment";
@@ -423,13 +427,8 @@ export async function buildStatsSummaryWithOptions(
 		configLoaded = true;
 		historyPath = config.paths.history;
 		logsPath = config.paths.logs;
-		groqConfigured =
-			typeof config.apiKeys.groq === "string" &&
-			config.apiKeys.groq.startsWith("gsk_") &&
-			config.apiKeys.groq.length > 6;
-		deepgramConfigured =
-			typeof config.apiKeys.deepgram === "string" &&
-			config.apiKeys.deepgram.length >= 24;
+		groqConfigured = isConfiguredGroqApiKey(config.apiKeys.groq);
+		deepgramConfigured = isValidDeepgramApiKey(config.apiKeys.deepgram);
 	} catch {
 		// Config may be incomplete during setup; stats can still be shown.
 	}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -2,7 +2,12 @@ import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	hasConfiguredTranscriptionApiKeys,
+	isValidDeepgramApiKey,
+} from "../src/config/api-keys";
 import { loadConfig } from "../src/config/loader";
+import { ConfigFileSchema } from "../src/config/schema";
 
 const TEST_DIR = join(
 	tmpdir(),
@@ -141,6 +146,41 @@ describe("Config Loader", () => {
 		expect(() => loadConfig(CONFIG_FILE)).toThrow(
 			"Deepgram API key is too long",
 		);
+	});
+
+	test("shared Deepgram key helper matches config schema", () => {
+		const validKeys = [
+			"4b5c1234-5678-90ab-cdef-1234567890ab",
+			"abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+		];
+		const invalidKeys = [
+			"12345678901234567890123456789012",
+			"not-a-valid-deepgram-key",
+		];
+
+		for (const deepgram of validKeys) {
+			const config = {
+				apiKeys: {
+					groq: "gsk_1234567890",
+					deepgram,
+				},
+			};
+			expect(isValidDeepgramApiKey(deepgram)).toBe(true);
+			expect(ConfigFileSchema.safeParse(config).success).toBe(true);
+			expect(hasConfiguredTranscriptionApiKeys(config)).toBe(true);
+		}
+
+		for (const deepgram of invalidKeys) {
+			const config = {
+				apiKeys: {
+					groq: "gsk_1234567890",
+					deepgram,
+				},
+			};
+			expect(isValidDeepgramApiKey(deepgram)).toBe(false);
+			expect(ConfigFileSchema.safeParse(config).success).toBe(false);
+			expect(hasConfiguredTranscriptionApiKeys(config)).toBe(false);
+		}
 	});
 
 	test("should validate valid boost words", () => {


### PR DESCRIPTION
Closes #51

## Summary
- add a shared schema-backed Deepgram API key helper
- use the helper in config schema, setup, config init, and stats readiness
- cover schema/helper/configured-readiness agreement for valid and invalid Deepgram keys

## Verification
- bun run tsc --noEmit
- bun test
- bun x npm pack