### PR TITLE
fix: deduplicate setup hotkey prompt

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -25,6 +25,7 @@ import {
 	rollbackProfileDerivedFields,
 } from "../setup/config-patch";
 import { getInstallCommand } from "../setup/environment";
+import { resolveSetupHotkey } from "../setup/hotkey";
 import {
 	collectDeviceSignals,
 	diffConfig,
@@ -302,6 +303,7 @@ async function collectInteractiveWizardUpdates(
 	options: SetupOptions,
 ): Promise<ConfigPatch> {
 	const updates: ConfigPatch = {};
+	const report = runSetupChecks();
 
 	const groqKey = askOptionalSecret(
 		"Enter Groq API Key (starts with gsk_) [enter to keep current]: ",
@@ -327,14 +329,20 @@ async function collectInteractiveWizardUpdates(
 		};
 	}
 
-	const useBuiltInHotkey = askYesNoQuit(
-		"Use built-in hotkey listener? (No = disable and use compositor bind)",
-	);
+	const useCompositorBinding =
+		report.environment.sessionType === "wayland"
+			? askYesNoQuit(
+					"Use compositor binding for the hotkey? (Recommended on Wayland; disables built-in listener)",
+				)
+			: !askYesNoQuit(
+					"Use built-in hotkey listener? (No = disable and use compositor bind)",
+				);
 	updates.behavior = {
 		...updates.behavior,
-		hotkey: useBuiltInHotkey
-			? (baseConfig.behavior?.hotkey ?? "Right Control")
-			: "disabled",
+		hotkey: resolveSetupHotkey(
+			baseConfig,
+			useCompositorBinding ? "compositor" : "built-in",
+		),
 	};
 
 	const notifications = askYesNoQuit("Enable notifications?");
@@ -524,28 +532,26 @@ function configureWaylandBehavior(options: SetupOptions): void {
 	const report = runSetupChecks();
 	if (report.environment.sessionType !== "wayland") return;
 
-	console.log(colors.bold("\nWayland hotkey setup"));
+	const config = loadPartialConfig();
+	const hotkey = config.behavior?.hotkey ?? "Right Control";
+	const hotkeyDisabled = hotkey.trim().toLowerCase() === "disabled";
+
+	console.log(colors.bold("\nWayland hotkey guidance"));
 	console.log(
 		"Built-in global hotkeys are limited on Wayland. Native compositor bindings are more reliable.",
 	);
-
-	if (!askYesNoQuit("Use compositor binding and disable built-in hotkey?")) {
-		return;
+	if (hotkeyDisabled) {
+		console.log(`${colors.green("✓")} Built-in hotkey disabled in config.`);
+		console.log(
+			`Add this to Hyprland: ${colors.cyan("bind = , code:105, exec, hyprvox toggle")}`,
+		);
+	} else {
+		console.log(
+			colors.yellow(
+				`Built-in hotkey remains enabled as ${colors.bold(hotkey)}; use compositor bindings for reliable system-wide Wayland hotkeys.`,
+			),
+		);
 	}
-
-	const config = loadPartialConfig();
-	const nextConfig = {
-		...config,
-		behavior: {
-			...config.behavior,
-			hotkey: "disabled",
-		},
-	};
-	if (!options.dryRun) saveConfig(nextConfig);
-	console.log(`${colors.green("✓")} Built-in hotkey disabled in config.`);
-	console.log(
-		`Add this to Hyprland: ${colors.cyan("bind = , code:105, exec, hyprvox toggle")}`,
-	);
 }
 
 function installServiceIfRequested(

--- a/src/output/notification.ts
+++ b/src/output/notification.ts
@@ -4,10 +4,15 @@ import { logger } from "../utils/logger";
 
 export type NotificationType = "info" | "success" | "warning" | "error";
 
-export const notify = (
+type LoadNotificationConfig = typeof loadConfig;
+type SendNotification = typeof notifier.notify;
+
+export const notifyWithConfig = (
 	title: string,
 	message: string,
 	type: NotificationType = "info",
+	loadConfigFn: LoadNotificationConfig = loadConfig,
+	sendNotification: SendNotification = notifier.notify.bind(notifier),
 ) => {
 	try {
 		// Suppress desktop side effects only in explicit test runtime.
@@ -19,7 +24,7 @@ export const notify = (
 			return;
 		}
 
-		const config = loadConfig();
+		const config = loadConfigFn();
 		if (!config.behavior.notifications) {
 			return;
 		}
@@ -31,7 +36,7 @@ export const notify = (
 			error: "dialog-error",
 		};
 
-		notifier.notify({
+		sendNotification({
 			title: `Voice CLI: ${title}`,
 			message,
 			icon: iconMap[type],
@@ -44,3 +49,9 @@ export const notify = (
 		logger.error({ err: error }, "Failed to send notification");
 	}
 };
+
+export const notify = (
+	title: string,
+	message: string,
+	type: NotificationType = "info",
+) => notifyWithConfig(title, message, type);

--- a/src/setup/hotkey.ts
+++ b/src/setup/hotkey.ts
@@ -1,0 +1,11 @@
+import type { ConfigFile } from "../config/schema";
+
+export type SetupHotkeyChoice = "built-in" | "compositor";
+
+export function resolveSetupHotkey(
+	baseConfig: ConfigFile,
+	choice: SetupHotkeyChoice,
+): string {
+	if (choice === "compositor") return "disabled";
+	return baseConfig.behavior?.hotkey ?? "Right Control";
+}

--- a/tests/notification.test.ts
+++ b/tests/notification.test.ts
@@ -6,16 +6,15 @@ vi.mock("node-notifier", () => ({
 	},
 }));
 
-vi.mock("../src/config/loader", () => ({
-	loadConfig: vi.fn(() => ({
-		behavior: { notifications: true },
-	})),
-}));
-
-import { notify } from "../src/output/notification";
+import { notifyWithConfig } from "../src/output/notification";
 import notifier from "node-notifier";
 
 describe("notification output", () => {
+	const loadConfig = () =>
+		({
+			behavior: { notifications: true },
+		}) as ReturnType<typeof import("../src/config/loader").loadConfig>;
+
 	afterEach(() => {
 		delete process.env.HYPRVOX_TEST_MODE;
 		vi.clearAllMocks();
@@ -23,12 +22,12 @@ describe("notification output", () => {
 
 	it("suppresses desktop notification in test mode", () => {
 		process.env.HYPRVOX_TEST_MODE = "1";
-		notify("Test", "Message", "info");
+		notifyWithConfig("Test", "Message", "info", loadConfig);
 		expect(notifier.notify).not.toHaveBeenCalled();
 	});
 
 	it("sends desktop notification when not in test mode", () => {
-		notify("Ready", "Done", "success");
+		notifyWithConfig("Ready", "Done", "success", loadConfig);
 		expect(notifier.notify).toHaveBeenCalledTimes(1);
 	});
 });

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -8,6 +8,7 @@ import {
 	type EnvironmentInfo,
 	getInstallCommand,
 } from "../src/setup/environment";
+import { resolveSetupHotkey } from "../src/setup/hotkey";
 
 function makeEnv(overrides: Partial<EnvironmentInfo> = {}): EnvironmentInfo {
 	return {
@@ -88,6 +89,14 @@ describe("setup config patches", () => {
 
 		expect(nextConfig.apiKeys).toEqual({ groq: "gsk_existing" });
 		expect(ConfigFileSchema.safeParse(nextConfig).success).toBe(true);
+	});
+
+	test("resolves hotkey from one setup decision without silent override", () => {
+		const config = { behavior: { hotkey: "Ctrl+Space" } };
+
+		expect(resolveSetupHotkey(config, "built-in")).toBe("Ctrl+Space");
+		expect(resolveSetupHotkey(config, "compositor")).toBe("disabled");
+		expect(resolveSetupHotkey({}, "built-in")).toBe("Right Control");
 	});
 });
 


### PR DESCRIPTION
Closes #52

## Summary
- resolve setup hotkey from one wizard decision and keep Wayland follow-up guidance-only
- add a pure hotkey resolver with setup test coverage
- remove a global notification test mock that made full-suite config tests race under parallel execution

## Verification
- bun run tsc --noEmit
- bun test
- bun x npm pack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup wizard now detects your desktop environment and automatically applies the appropriate hotkey configuration method (compositor binding for Wayland, built-in listener for other systems).
  * Improved post-setup guidance for Wayland users, including relevant configuration snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->