### PR TITLE
feat: add setup provider verification

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -10,7 +10,11 @@ import {
 	hasConfiguredTranscriptionApiKeys,
 	isValidDeepgramApiKey,
 } from "../config/api-keys";
-import { DEFAULT_CONFIG_FILE, loadConfig } from "../config/loader";
+import {
+	DEFAULT_CONFIG_DIR,
+	DEFAULT_CONFIG_FILE,
+	loadConfig,
+} from "../config/loader";
 import type { ConfigFile } from "../config/schema";
 import { saveConfig } from "../config/writer";
 import {
@@ -277,14 +281,8 @@ const SETUP_REPORT_FILE = join(
 	"vox",
 	"setup-report.json",
 );
-const DAEMON_PID_FILE = join(homedir(), ".config", "hypr", "vox", "daemon.pid");
-const DAEMON_STATE_FILE = join(
-	homedir(),
-	".config",
-	"hypr",
-	"vox",
-	"daemon.state",
-);
+const DAEMON_PID_FILE = join(DEFAULT_CONFIG_DIR, "daemon.pid");
+const DAEMON_STATE_FILE = join(DEFAULT_CONFIG_DIR, "daemon.state");
 
 function writeSetupReport(payload: Record<string, unknown>): void {
 	mkdirSync(dirname(SETUP_REPORT_FILE), { recursive: true });
@@ -408,6 +406,31 @@ function getRunningDaemonPid(): number | null {
 	}
 }
 
+function sendDaemonToggleSignal(pid: number): {
+	ok: boolean;
+	reason?: string;
+	message?: string;
+} {
+	try {
+		process.kill(pid, "SIGUSR1");
+		return { ok: true };
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ESRCH") {
+			return {
+				ok: false,
+				reason: "daemon_terminated",
+				message: "Daemon exited before verification could signal it.",
+			};
+		}
+		return {
+			ok: false,
+			reason: "daemon_signal_failed",
+			message: `Failed to signal daemon: ${err.message}`,
+		};
+	}
+}
+
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -461,7 +484,11 @@ async function runRecordToTranscriptVerification(
 		"Press Enter to start recording, then speak a short phrase.",
 	);
 	const verificationStartedAt = Date.now();
-	process.kill(pid, "SIGUSR1");
+	const startSignal = sendDaemonToggleSignal(pid);
+	if (!startSignal.ok) {
+		console.log(colors.red(startSignal.message ?? "Failed to signal daemon."));
+		return { passed: false, reason: startSignal.reason };
+	}
 	const recording = await waitForDaemonStatus(["recording"], 5000);
 	if (recording?.status !== "recording") {
 		console.log(colors.red("Daemon did not enter recording state."));
@@ -469,7 +496,11 @@ async function runRecordToTranscriptVerification(
 	}
 
 	readlineSync.question("Recording... press Enter to stop and transcribe.");
-	process.kill(pid, "SIGUSR1");
+	const stopSignal = sendDaemonToggleSignal(pid);
+	if (!stopSignal.ok) {
+		console.log(colors.red(stopSignal.message ?? "Failed to signal daemon."));
+		return { passed: false, reason: stopSignal.reason };
+	}
 	const completed = await waitForDaemonStatus(["idle", "error"], 90000);
 	if (!completed) {
 		console.log(colors.red("Timed out waiting for transcription result."));

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { Command } from "commander";
@@ -33,6 +33,15 @@ import {
 	recommendProfile,
 	type SetupProfileId,
 } from "../setup/profile";
+import {
+	type ProviderVerificationResult,
+	type SetupVerificationReport,
+	verifyProviderAuth,
+} from "../setup/verification";
+import type { DaemonState } from "../daemon/service";
+import { DeepgramTranscriber } from "../transcribe/deepgram";
+import { GroqClient } from "../transcribe/groq";
+import { loadHistory } from "../utils/history";
 
 export interface SetupOptions {
 	check?: boolean;
@@ -41,6 +50,7 @@ export interface SetupOptions {
 	skipService?: boolean;
 	nonInteractive?: boolean;
 	advanced?: boolean;
+	verify?: boolean;
 }
 
 class SetupAbortedError extends Error {
@@ -267,6 +277,14 @@ const SETUP_REPORT_FILE = join(
 	"vox",
 	"setup-report.json",
 );
+const DAEMON_PID_FILE = join(homedir(), ".config", "hypr", "vox", "daemon.pid");
+const DAEMON_STATE_FILE = join(
+	homedir(),
+	".config",
+	"hypr",
+	"vox",
+	"daemon.state",
+);
 
 function writeSetupReport(payload: Record<string, unknown>): void {
 	mkdirSync(dirname(SETUP_REPORT_FILE), { recursive: true });
@@ -296,6 +314,203 @@ function runPostApplySmokeTest(apiKeysConfigured: boolean): {
 		reasons.push("config_check_failed");
 	}
 	return { passed: reasons.length === 0, reasons };
+}
+
+function verificationIcon(result: ProviderVerificationResult): string {
+	if (result.status === "pass") return colors.green("✓");
+	if (result.status === "fail") return colors.red("x");
+	if (result.status === "warn") return colors.yellow("!");
+	return colors.dim("-");
+}
+
+function printVerificationReport(report: SetupVerificationReport): void {
+	console.log(colors.bold("\nVerification"));
+	for (const result of report.results) {
+		console.log(
+			`  ${verificationIcon(result)} ${colors.bold(result.provider)} ${colors.dim(result.message)}`,
+		);
+	}
+	if (report.offline) {
+		console.log(
+			colors.yellow(
+				"Network verification could not complete. Setup can continue; retry when online.",
+			),
+		);
+	}
+}
+
+function createLiveAuthTransport() {
+	const groq = new GroqClient();
+	const deepgram = new DeepgramTranscriber();
+	return {
+		groq: async () => {
+			await groq.checkConnection();
+		},
+		deepgram: async () => {
+			await deepgram.checkConnection();
+		},
+	};
+}
+
+async function runAuthVerification(
+	options: SetupOptions,
+	apiKeysConfigured: boolean,
+): Promise<SetupVerificationReport | null> {
+	if (!apiKeysConfigured) {
+		console.log(
+			colors.yellow(
+				"Skipping provider verification until both API keys are set.",
+			),
+		);
+		return null;
+	}
+
+	if (options.dryRun) {
+		console.log(
+			colors.yellow("Skipping live provider verification during --dry-run."),
+		);
+		return null;
+	}
+
+	const config = loadConfig(DEFAULT_CONFIG_FILE, true);
+	const report = await verifyProviderAuth(config, createLiveAuthTransport());
+	printVerificationReport(report);
+
+	if (
+		report.hasBlockingFailure &&
+		!options.nonInteractive &&
+		!askYesNoQuit("Provider authentication failed. Continue setup anyway?")
+	) {
+		throw new SetupAbortedError();
+	}
+
+	return report;
+}
+
+function readDaemonState(): DaemonState | null {
+	if (!existsSync(DAEMON_STATE_FILE)) return null;
+	try {
+		return JSON.parse(readFileSync(DAEMON_STATE_FILE, "utf-8")) as DaemonState;
+	} catch {
+		return null;
+	}
+}
+
+function getRunningDaemonPid(): number | null {
+	if (!existsSync(DAEMON_PID_FILE)) return null;
+	try {
+		const pid = Number.parseInt(readFileSync(DAEMON_PID_FILE, "utf-8"), 10);
+		if (!Number.isFinite(pid)) return null;
+		process.kill(pid, 0);
+		return pid;
+	} catch {
+		return null;
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForDaemonStatus(
+	statuses: DaemonState["status"][],
+	timeoutMs: number,
+): Promise<DaemonState | null> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const state = readDaemonState();
+		if (state && statuses.includes(state.status)) return state;
+		await sleep(250);
+	}
+	return readDaemonState();
+}
+
+async function runRecordToTranscriptVerification(
+	options: SetupOptions,
+): Promise<{ passed: boolean; reason?: string; transcript?: string } | null> {
+	if (!options.verify) return null;
+	if (options.nonInteractive) {
+		console.log(
+			colors.yellow("Skipping --verify record test in non-interactive mode."),
+		);
+		return { passed: false, reason: "non_interactive" };
+	}
+
+	const pid = getRunningDaemonPid();
+	if (!pid) {
+		console.log(
+			colors.yellow(
+				"--verify requires an already-running daemon. Start it with hyprvox start, then rerun setup --verify.",
+			),
+		);
+		return { passed: false, reason: "daemon_not_running" };
+	}
+
+	const before = readDaemonState();
+	if (before && before.status !== "idle" && before.status !== "error") {
+		console.log(
+			colors.yellow(
+				`Cannot run --verify while daemon is ${before.status}. Wait for it to become idle.`,
+			),
+		);
+		return { passed: false, reason: `daemon_${before.status}` };
+	}
+
+	console.log(colors.bold("\nRecord-to-transcript verification"));
+	readlineSync.question(
+		"Press Enter to start recording, then speak a short phrase.",
+	);
+	const verificationStartedAt = Date.now();
+	process.kill(pid, "SIGUSR1");
+	const recording = await waitForDaemonStatus(["recording"], 5000);
+	if (recording?.status !== "recording") {
+		console.log(colors.red("Daemon did not enter recording state."));
+		return { passed: false, reason: "recording_not_started" };
+	}
+
+	readlineSync.question("Recording... press Enter to stop and transcribe.");
+	process.kill(pid, "SIGUSR1");
+	const completed = await waitForDaemonStatus(["idle", "error"], 90000);
+	if (!completed) {
+		console.log(colors.red("Timed out waiting for transcription result."));
+		return { passed: false, reason: "timeout" };
+	}
+	if (completed.status === "error") {
+		console.log(
+			colors.red(
+				`Verification failed: ${completed.lastError ?? "daemon error"}`,
+			),
+		);
+		return { passed: false, reason: "daemon_error" };
+	}
+	if (
+		before?.lastTranscription &&
+		completed.lastTranscription === before.lastTranscription
+	) {
+		console.log(
+			colors.red("Daemon returned idle without a new transcription."),
+		);
+		return { passed: false, reason: "no_new_transcription" };
+	}
+
+	const history = await loadHistory();
+	const transcript = history
+		.filter(
+			(item) => new Date(item.timestamp).getTime() >= verificationStartedAt,
+		)
+		.at(-1)
+		?.text.trim();
+	if (!transcript) {
+		console.log(
+			colors.red(
+				"Verification completed but no new transcript was found in history.",
+			),
+		);
+		return { passed: false, reason: "missing_transcript" };
+	}
+
+	console.log(`${colors.green("✓")} Transcript: ${colors.bold(transcript)}`);
+	return { passed: true, transcript };
 }
 
 async function collectInteractiveWizardUpdates(
@@ -429,7 +644,7 @@ async function configureInteractively(options: SetupOptions): Promise<boolean> {
 			!options.nonInteractive &&
 			!askYesNoQuit("Do you want to update configuration now?")
 		) {
-			return true;
+			return hasConfiguredTranscriptionApiKeys(existingConfig);
 		}
 	}
 
@@ -710,6 +925,7 @@ async function runInteractiveSetup(options: SetupOptions): Promise<void> {
 	}
 
 	const apiKeysConfigured = await runConfigSetup(options);
+	const verification = await runAuthVerification(options, apiKeysConfigured);
 	const smoke = runPostApplySmokeTest(apiKeysConfigured);
 	if (!smoke.passed && selectedProfileId && profileDiff.length > 0) {
 		console.log(
@@ -720,6 +936,7 @@ async function runInteractiveSetup(options: SetupOptions): Promise<void> {
 		if (!options.dryRun) saveConfig(rolledBack);
 	}
 	installServiceIfRequested(options, initialReport, apiKeysConfigured);
+	const recordVerification = await runRecordToTranscriptVerification(options);
 
 	const finalReport = runSetupChecks();
 	writeSetupReport({
@@ -732,6 +949,8 @@ async function runInteractiveSetup(options: SetupOptions): Promise<void> {
 			confidence: selectedProfileConfidence,
 			diff: profileDiff,
 		},
+		verification,
+		recordVerification,
 		smokeTest: smoke,
 		initialReady: initialReport.ready,
 		finalReady: finalReport.ready,
@@ -757,6 +976,10 @@ export const setupCommand = new Command("setup")
 		"Run setup without prompts (automation-friendly)",
 	)
 	.option("--advanced", "Enable advanced setup questions")
+	.option(
+		"--verify",
+		"Run an opt-in record-to-transcript verification after provider auth checks",
+	)
 	.action(async (options: SetupOptions) => {
 		try {
 			if (options.check || options.json) {

--- a/src/setup/verification.ts
+++ b/src/setup/verification.ts
@@ -1,0 +1,169 @@
+import type { ConfigFile } from "../config/schema";
+import { getErrorMessage } from "../utils/errors";
+
+export type VerificationProvider = "groq" | "deepgram";
+export type VerificationStatus = "pass" | "fail" | "warn" | "skip";
+
+export interface ProviderVerificationResult {
+	provider: VerificationProvider;
+	status: VerificationStatus;
+	message: string;
+	blocking: boolean;
+}
+
+export interface SetupVerificationReport {
+	results: ProviderVerificationResult[];
+	hasBlockingFailure: boolean;
+	offline: boolean;
+}
+
+export interface ProviderAuthTransport {
+	groq?: () => Promise<void>;
+	deepgram?: () => Promise<void>;
+}
+
+function getNestedStatus(error: unknown): number | undefined {
+	if (typeof error !== "object" || error === null) return undefined;
+	const record = error as Record<string, unknown>;
+	const status = record.status ?? record.code;
+	if (typeof status === "number") return status;
+
+	const response = record.response;
+	if (typeof response === "object" && response !== null) {
+		const responseStatus = (response as Record<string, unknown>).status;
+		if (typeof responseStatus === "number") return responseStatus;
+	}
+
+	return undefined;
+}
+
+function getStringCode(error: unknown): string | undefined {
+	if (typeof error !== "object" || error === null) return undefined;
+	const code = (error as Record<string, unknown>).code;
+	return typeof code === "string" ? code : undefined;
+}
+
+function isInvalidAuthError(error: unknown): boolean {
+	const status = getNestedStatus(error);
+	if (status === 401 || status === 403) return true;
+
+	const code = getStringCode(error);
+	if (code === "GROQ_INVALID_KEY" || code === "DEEPGRAM_INVALID_KEY") {
+		return true;
+	}
+
+	const message = getErrorMessage(error).toLowerCase();
+	return (
+		message.includes("invalid api key") ||
+		message.includes("unauthorized") ||
+		message.includes("forbidden") ||
+		message.includes("401") ||
+		message.includes("403")
+	);
+}
+
+function isOfflineError(error: unknown): boolean {
+	if (getNestedStatus(error) !== undefined) return false;
+	const code = getStringCode(error);
+	if (
+		code &&
+		[
+			"ABORT_ERR",
+			"ECONNREFUSED",
+			"ECONNRESET",
+			"ENETUNREACH",
+			"ENOTFOUND",
+			"ETIMEDOUT",
+			"EAI_AGAIN",
+			"UND_ERR_CONNECT_TIMEOUT",
+		].includes(code)
+	) {
+		return true;
+	}
+
+	const message = getErrorMessage(error).toLowerCase();
+	return (
+		message.includes("fetch failed") ||
+		message.includes("network") ||
+		message.includes("offline") ||
+		message.includes("timed out")
+	);
+}
+
+function providerKey(
+	config: ConfigFile,
+	provider: VerificationProvider,
+): string | undefined {
+	return config.apiKeys?.[provider];
+}
+
+async function verifyProvider(
+	provider: VerificationProvider,
+	config: ConfigFile,
+	transport: ProviderAuthTransport,
+): Promise<ProviderVerificationResult> {
+	if (!providerKey(config, provider)) {
+		return {
+			provider,
+			status: "skip",
+			message: "API key is not configured.",
+			blocking: false,
+		};
+	}
+
+	const check = transport[provider];
+	if (!check) {
+		return {
+			provider,
+			status: "skip",
+			message: "No auth check transport is available.",
+			blocking: false,
+		};
+	}
+
+	try {
+		await check();
+		return {
+			provider,
+			status: "pass",
+			message: "Authenticated request succeeded.",
+			blocking: false,
+		};
+	} catch (error) {
+		if (isInvalidAuthError(error)) {
+			return {
+				provider,
+				status: "fail",
+				message: `Authentication failed: ${getErrorMessage(error)}`,
+				blocking: true,
+			};
+		}
+
+		return {
+			provider,
+			status: "warn",
+			message: `${isOfflineError(error) ? "Network/offline check failed" : "Connectivity check failed"}: ${getErrorMessage(error)}`,
+			blocking: false,
+		};
+	}
+}
+
+export async function verifyProviderAuth(
+	config: ConfigFile,
+	transport: ProviderAuthTransport,
+): Promise<SetupVerificationReport> {
+	const results = await Promise.all([
+		verifyProvider("groq", config, transport),
+		verifyProvider("deepgram", config, transport),
+	]);
+
+	return {
+		results,
+		hasBlockingFailure: results.some((result) => result.blocking),
+		offline: results.some(
+			(result) =>
+				result.status === "warn" &&
+				result.message.toLowerCase().includes("network/offline"),
+		),
+	};
+}

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -9,6 +9,7 @@ import {
 	getInstallCommand,
 } from "../src/setup/environment";
 import { resolveSetupHotkey } from "../src/setup/hotkey";
+import { verifyProviderAuth } from "../src/setup/verification";
 
 function makeEnv(overrides: Partial<EnvironmentInfo> = {}): EnvironmentInfo {
 	return {
@@ -97,6 +98,88 @@ describe("setup config patches", () => {
 		expect(resolveSetupHotkey(config, "built-in")).toBe("Ctrl+Space");
 		expect(resolveSetupHotkey(config, "compositor")).toBe("disabled");
 		expect(resolveSetupHotkey({}, "built-in")).toBe("Right Control");
+	});
+});
+
+describe("setup provider verification", () => {
+	const config = {
+		apiKeys: {
+			groq: "gsk_configured",
+			deepgram: "4b5c1234-5678-90ab-cdef-1234567890ab",
+		},
+	};
+
+	test("passes when both injected provider checks succeed", async () => {
+		const report = await verifyProviderAuth(config, {
+			groq: async () => {},
+			deepgram: async () => {},
+		});
+
+		expect(report.hasBlockingFailure).toBe(false);
+		expect(report.offline).toBe(false);
+		expect(report.results).toEqual([
+			expect.objectContaining({ provider: "groq", status: "pass" }),
+			expect.objectContaining({ provider: "deepgram", status: "pass" }),
+		]);
+	});
+
+	test("marks invalid authentication as a blocking failure", async () => {
+		const report = await verifyProviderAuth(config, {
+			groq: async () => {
+				throw Object.assign(new Error("401 unauthorized"), { status: 401 });
+			},
+			deepgram: async () => {},
+		});
+
+		expect(report.hasBlockingFailure).toBe(true);
+		expect(report.results).toContainEqual(
+			expect.objectContaining({
+				provider: "groq",
+				status: "fail",
+				blocking: true,
+			}),
+		);
+	});
+
+	test("warns and continues on offline/network failures", async () => {
+		const report = await verifyProviderAuth(config, {
+			groq: async () => {},
+			deepgram: async () => {
+				throw Object.assign(new Error("fetch failed"), { code: "ENOTFOUND" });
+			},
+		});
+
+		expect(report.hasBlockingFailure).toBe(false);
+		expect(report.offline).toBe(true);
+		expect(report.results).toContainEqual(
+			expect.objectContaining({
+				provider: "deepgram",
+				status: "warn",
+				blocking: false,
+			}),
+		);
+	});
+
+	test("skips missing keys without calling provider transport", async () => {
+		let called = false;
+		const report = await verifyProviderAuth(
+			{},
+			{
+				groq: async () => {
+					called = true;
+				},
+				deepgram: async () => {
+					called = true;
+				},
+			},
+		);
+
+		expect(called).toBe(false);
+		expect(report.hasBlockingFailure).toBe(false);
+		expect(report.results).toEqual([
+			expect.objectContaining({ provider: "groq", status: "skip" }),
+			expect.objectContaining({ provider: "deepgram", status: "skip" }),
+		]);
 	});
 });
 


### PR DESCRIPTION
Closes #53

## Summary
- add setup-time Groq and Deepgram auth verification with per-provider pass/fail/warn reporting
- keep provider auth checks injectable and unit-tested without real network calls
- add setup --verify manual record-to-transcript flow that uses an existing or newly installed daemon and prints the resulting transcript from history

## Validation
- bun run tsc --noEmit
- bun test
- bun x npm pack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--verify` flag to the setup command for optional provider authentication and record-to-transcript verification
  * Setup now validates Groq and Deepgram provider connectivity and reports verification status
  * Invalid authentication credentials trigger blocking failures; network issues produce non-blocking warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->