### PR TITLE
fix: stop crash-recovery test leaking overlays; park overlay off-screen when idle

### DIFF
--- a/overlay/src/global.d.ts
+++ b/overlay/src/global.d.ts
@@ -17,6 +17,7 @@ export interface ElectronAPI {
 	) => () => void;
 	getDaemonState: () => Promise<DaemonState>;
 	getConnectionStatus: () => Promise<ConnectionStatus>;
+	setOverlayVisible: (visible: boolean) => void;
 }
 
 declare global {

--- a/overlay/src/main.ts
+++ b/overlay/src/main.ts
@@ -42,6 +42,9 @@ let mainWindow: BrowserWindow | null = null;
 let ipcClient: IPCClient | null = null;
 let previousStatus: string = "idle";
 let ipcConnectionTimeout: NodeJS.Timeout | null = null;
+let restingPosition = { x: 0, y: 0 };
+let parkedPosition = { x: 0, y: 0 };
+let overlayVisible = false;
 
 process.on("uncaughtException", (err) => {
 	console.error("[Overlay] Uncaught exception:", err);
@@ -61,11 +64,23 @@ function createOverlayWindow(
 	const x = Math.floor((screenWidth - config.width) / 2);
 	const y = screenHeight - config.height - config.marginBottom;
 
+	// Resting spot (visible) and a parked spot fully below the monitor. The
+	// window stays mapped, but when idle we move it off-screen instead of
+	// leaving it on the desktop, so the compositor has no transparent rect to
+	// blur/round into a "ghost pill" at idle. Moving an already-mapped window is
+	// cheap (no re-map) and the compositor animates it into view.
+	restingPosition = { x, y };
+	parkedPosition = {
+		x,
+		y: display.bounds.y + display.bounds.height + config.height,
+	};
+	overlayVisible = false;
+
 	const windowOptions: BrowserWindowConstructorOptions = {
 		width: config.width,
 		height: config.height,
-		x,
-		y,
+		x: parkedPosition.x,
+		y: parkedPosition.y,
 		frame: false,
 		transparent: true,
 		show: true,
@@ -124,6 +139,21 @@ function createOverlayWindow(
 	});
 
 	return window;
+}
+
+// Move the always-mapped window between its resting (visible) and parked
+// (off-screen) positions. Driven by the renderer's own visibility, which
+// already folds in success/error hold timers, so animations are never cut off.
+function setOverlayWindowVisible(visible: boolean): void {
+	if (!mainWindow || mainWindow.isDestroyed()) {
+		return;
+	}
+	if (overlayVisible === visible) {
+		return;
+	}
+	overlayVisible = visible;
+	const target = visible ? restingPosition : parkedPosition;
+	mainWindow.setPosition(target.x, target.y);
 }
 
 function setupIPCClient(): void {
@@ -228,6 +258,10 @@ app.whenReady().then(() => {
 
 	ipcMain.on("window-ready", () => {
 		console.log("Overlay window ready");
+	});
+
+	ipcMain.on("overlay-visible", (_event, visible: boolean) => {
+		setOverlayWindowVisible(Boolean(visible));
 	});
 
 	ipcMain.handle("get-daemon-state", () => {

--- a/overlay/src/preload.ts
+++ b/overlay/src/preload.ts
@@ -53,6 +53,9 @@ const electronAPI = {
 	getConnectionStatus: (): Promise<ConnectionStatus> => {
 		return ipcRenderer.invoke("get-connection-status");
 	},
+	setOverlayVisible: (visible: boolean): void => {
+		ipcRenderer.send("overlay-visible", visible);
+	},
 };
 
 contextBridge.exposeInMainWorld("electronAPI", electronAPI);

--- a/overlay/src/renderer/App.tsx
+++ b/overlay/src/renderer/App.tsx
@@ -161,7 +161,11 @@ function getAriaStatusText(state: OverlayState, errorMessage?: string): string {
 
 export function App() {
 	const { overlayState, errorMessage } = useDaemonState();
-	const styles = getStateStyles(overlayState);
+	const visible = overlayState !== "hidden";
+	// Retain the last visible state so the bar keeps its appearance while it
+	// slides back out of frame, instead of blanking before the animation runs.
+	const [renderState, setRenderState] = useState<OverlayState>(overlayState);
+	const styles = getStateStyles(visible ? overlayState : renderState);
 
 	const isRecording = overlayState === "recording";
 	const isProcessing = overlayState === "processing";
@@ -193,6 +197,19 @@ export function App() {
 	useEffect(() => {
 		previousOverlayStateRef.current = overlayState;
 	}, [overlayState]);
+
+	useEffect(() => {
+		if (overlayState !== "hidden") {
+			setRenderState(overlayState);
+		}
+	}, [overlayState]);
+
+	// Drive the window's on-screen/off-screen position from the renderer's own
+	// visibility. The main process moves the (always-mapped) window in or out of
+	// frame; the compositor animates the slide.
+	useEffect(() => {
+		window.electronAPI?.setOverlayVisible(visible);
+	}, [visible]);
 
 	useEffect(() => {
 		if (nextIndicatorState === currentIndicator?.state) {
@@ -271,24 +288,24 @@ export function App() {
 		};
 	}, []);
 
-	if (overlayState === "hidden") {
-		return null;
-	}
-
+	// The window stays mapped and is moved off-screen when idle (see main.ts), so
+	// the content is never torn down — it stays mounted here. The compositor
+	// animates the window slide; we just cross-fade the bar's own visuals.
 	return (
 		<div
-			className={`overlay-container state-${overlayState}`}
+			className={`overlay-container state-${visible ? overlayState : renderState}`}
+			data-visible={visible}
 			style={{
 				width: "100%",
 				height: "100%",
 				background: styles.background,
 				borderRadius: "8px",
-				display: styles.display,
+				display: "flex",
 				alignItems: "center",
 				justifyContent: "center",
 				position: "relative",
-				opacity: styles.opacity,
-				transition: "background 0.3s ease, opacity 0.3s ease",
+				opacity: visible ? styles.opacity : 0,
+				transition: "background 0.3s ease, opacity 0.26s ease",
 			}}
 		>
 			{showWaveform && (

--- a/tests/integration/crash_recovery.test.ts
+++ b/tests/integration/crash_recovery.test.ts
@@ -35,6 +35,11 @@ describe.skipIf(isCI)("Daemon Crash Recovery Integration", () => {
 				audioDevice: "default",
 				clipboard: { append: true, minDuration: 0.6, maxDuration: 300 },
 			},
+			// Disable the overlay: this suite exercises the daemon, not the GUI.
+			// Leaving it enabled spawns a real Electron window on the dev's live
+			// Wayland session, and because the overlay is detached it survives the
+			// SIGKILLs below and leaks as an orphan.
+			overlay: { enabled: false, autoStart: false },
 			paths: {
 				logs: join(configDir, "logs"),
 				history: join(configDir, "history.json"),
@@ -69,7 +74,14 @@ describe.skipIf(isCI)("Daemon Crash Recovery Integration", () => {
 					readFileSync(overlayPidFile, "utf-8").trim(),
 					10,
 				);
-				process.kill(overlayPid, "SIGKILL");
+				// The overlay is spawned detached (its own process group), so a
+				// SIGKILL to the lone PID can orphan the child Electron processes.
+				// Kill the whole group; fall back to the single PID.
+				try {
+					process.kill(-overlayPid, "SIGKILL");
+				} catch (_e) {
+					process.kill(overlayPid, "SIGKILL");
+				}
 			} catch (_e) {}
 		}
 


### PR DESCRIPTION
## Summary

Two related overlay reliability fixes found while investigating "many overlapping overlays on screen."

### 1. Crash-recovery test leaked real overlay windows
`tests/integration/crash_recovery.test.ts` started a real daemon under a temp `HOME` without disabling the overlay, so each run spawned a genuine Electron overlay on the dev's Wayland session. Because the overlay is spawned detached, the test's repeated `SIGKILL`s on the daemon orphaned the window instead of reaping it, and `afterEach` only killed the single PID — leaking one overlay per run.

- Disable the overlay in the test daemon config (this suite exercises the daemon, not the GUI).
- Kill the overlay **process group** in `afterEach`, with a single-PID fallback.

### 2. Always-mapped overlay showed a "ghost pill" at idle
Since #55 the overlay window stays mapped to avoid the ~1.1s re-map latency. On a blur-enabled compositor (Hyprland), an always-mapped *transparent* window still gets its rectangle blurred/rounded, leaving a faint pill at bottom-center even when idle.

Fix: keep the window mapped but **move it off-screen when idle** and back to its resting spot when active. The renderer reports its own visibility (which already folds in success/error hold timers) over a new `overlay-visible` IPC channel; the main process slides the window between parked and resting positions. The compositor animates the move — no re-map, no DOM remount.

## Verification
- `bun run tsc --noEmit` clean; `cd overlay && bun run build` green.
- `bun test tests/integration/crash_recovery.test.ts` → 2 pass / 0 fail; no overlay leaked after the run.
- Live (Hyprland): idle parks window at y=1140 (below 1080px monitor, not clamped); recording moves it on-screen (y=900); returns to parked on idle.