### PR TITLE
Add live dictation and Soniox provider bypass

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,11 +25,11 @@ The on-screen status surface that reflects live daemon state.
 _Avoid_: popup, HUD
 
 **Live Dictation**:
-Entering stable transcript text into the currently focused text field while a recording is still active, then preserving the final transcript through the normal clipboard and history paths.
+Entering stable transcript text in the currently focused text field while a recording is still active, then preserving the final transcript through the normal clipboard and history paths. When driven by Deepgram streaming, the full quality pipeline runs after stop. When driven by Soniox, it operates as a [[Provider Bypass]]. During recording, only final tokens are typed — interim/partial tokens are discarded to avoid flickering and fragility. Tokens are joined with a single space; double spaces are collapsed and trailing spaces are trimmed. Paragraph breaks are inserted during live typing when the gap between consecutive Soniox token messages exceeds `liveDictation.soniox.paragraphPauseMs` (default: 3000ms) — a paragraph break is emitted as a double-space prefix to the next token. Self-corrections are not backspaced — mistakes remain in the typed text and can be corrected manually after recording stops. After stop, a minimal Groq/Llama 3.3 pass adds only paragraph breaks at natural sentence boundaries — no filler removal, no punctuation fixes, no rewriting. A config option (`liveDictation.retypeFormatted`, default: true) controls whether the LLM-formatted text replaces what was typed (via Home + Shift+End selection + retype, avoiding Ctrl+A risk in editors) or only affects clipboard/history (off). Per-token debug logging is available at `LOG_LEVEL=debug`. Structured perf entries (`type: "perf"`) include `paragraphBreakCount` and `llmFormattingMs` for statistical analysis.
 _Avoid_: live paste, streaming paste
 
 **Provider Bypass**:
-A recording path that uses one live transcription provider directly and skips the Groq plus Deepgram merge and quality pipeline by design.
+A recording path that uses one live transcription provider directly and skips the Groq plus Deepgram merge and quality pipeline by design. The Soniox live dictation path is the primary instance — it trusts Soniox output for real-time typing and skips validation, hallucination detection, and recovery entirely. Token spacing is normalized (joined with space, double spaces collapsed, trailing spaces trimmed) and paragraph breaks are inserted based on configurable inter-token pause thresholds. After stop, a minimal LLM formatting pass may add paragraph breaks only (no rewriting). See [[Live Dictation]] for the full formatting pipeline.
 _Avoid_: fallback, fast mode
 
 ## Observability

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,14 @@ _Avoid_: hotkey, shortcut
 The on-screen status surface that reflects live daemon state.
 _Avoid_: popup, HUD
 
+**Live Dictation**:
+Entering stable transcript text into the currently focused text field while a recording is still active, then preserving the final transcript through the normal clipboard and history paths.
+_Avoid_: live paste, streaming paste
+
+**Provider Bypass**:
+A recording path that uses one live transcription provider directly and skips the Groq plus Deepgram merge and quality pipeline by design.
+_Avoid_: fallback, fast mode
+
 ## Observability
 
 **Readiness**:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,6 +22,7 @@ If an API key is missing from `config.json`, the application will fall back to t
 - `GROQ_API_KEY`: Fallback for `apiKeys.groq`
 - `GROQ_FALLBACK_API_KEY`: Fallback for `apiKeys.groqFallback`
 - `DEEPGRAM_API_KEY`: Fallback for `apiKeys.deepgram`
+- `SONIOX_API_KEY`: Fallback for `apiKeys.soniox` when Soniox live dictation is enabled
 
 ### Logging
 - `LOG_LEVEL`: Sets the minimum logging level. Options: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `silent`. Default: `info`.
@@ -44,7 +45,8 @@ The configuration is a JSON file structured into several sections.
   "apiKeys": {
     "groq": "gsk_...",
     "groqFallback": "gsk_...",
-    "deepgram": "00000000-0000-0000-0000-000000000000"
+    "deepgram": "00000000-0000-0000-0000-000000000000",
+    "soniox": "soniox_..."
   },
   "behavior": {
     "hotkey": "Right Control",
@@ -87,6 +89,14 @@ The configuration is a JSON file structured into several sections.
       "Groq",
       "Deepgram"
     ]
+  },
+  "liveDictation": {
+    "enabled": false,
+    "insertionCommand": "auto",
+    "soniox": {
+      "enabled": false,
+      "triggerKey": "Right Alt"
+    }
   }
 }
 ```
@@ -104,6 +114,7 @@ Authentication credentials for the transcription services.
 | `groq` | String | N/A | API key for Groq (Whisper V3). | Must start with `gsk_`. | [Groq Console](https://console.groq.com/keys) |
 | `groqFallback` | String | Optional | Secondary Groq API key used only when the primary merge key is rate-limited/quota-limited. | Must start with `gsk_` if provided. | [Groq Console](https://console.groq.com/keys) |
 | `deepgram` | String | N/A | API key for Deepgram (Nova-3). | 40-char hex string or UUID. | [Deepgram Console](https://console.deepgram.com/) |
+| `soniox` | String | Optional | API key for Soniox real-time STT. Required only when `liveDictation.soniox.enabled` is used. | Non-empty string. | [Soniox Console](https://console.soniox.com/) |
 
 #### How to obtain API Keys
 
@@ -116,6 +127,11 @@ Authentication credentials for the transcription services.
    - Go to the [Deepgram Console](https://console.deepgram.com/).
    - Navigate to **API Keys** and create a new key.
    - **Format**: The key is typically a **40-character hexadecimal string** (e.g., `abcdef1234567890abcdef1234567890abcdef12`). Legacy keys or specific project IDs might use a UUID format, both are supported.
+
+3. **Soniox API Key**:
+   - Go to the [Soniox Console](https://console.soniox.com/).
+   - Create an API key for real-time speech-to-text.
+   - Hyprvox reads it from `apiKeys.soniox` or `SONIOX_API_KEY`.
 
 ---
 
@@ -299,6 +315,27 @@ In streaming mode, performance logs include Deepgram finalization observability:
 - `deepgramHadSpeechFinal`
 
 These fields are for analysis and future tuning. Do not treat a frequent `finalize_timeout` by itself as proof that endpointing should change; compare the final transcript quality and late finalization signals first.
+
+### 5. Live Dictation (`liveDictation`)
+
+Live Dictation controls focused-text insertion while recording. It is disabled by default.
+
+| Option | Type | Default | Description | Validation Rules |
+| :--- | :--- | :--- | :--- | :--- |
+| `enabled` | Boolean | `false` | Type stable live transcript text into the currently focused input during the normal streaming path. | Requires `transcription.streaming: true` to receive Deepgram live transcript events. |
+| `insertionCommand` | String | `"auto"` | Command used for focused text insertion. | `"auto"`, `"wtype"`, or `"xdotool"`. |
+| `soniox.enabled` | Boolean | `false` | Enable the separate Soniox provider-bypass hotkey. | Requires `apiKeys.soniox` or `SONIOX_API_KEY` when used. |
+| `soniox.triggerKey` | String | `"Right Alt"` | Separate hotkey for Soniox live dictation. | Same hotkey format as `behavior.hotkey`. |
+
+#### Normal Live Dictation
+
+When `liveDictation.enabled` and `transcription.streaming` are both enabled, Hyprvox types committed Deepgram streaming transcript chunks into the focused input as they arrive. The final transcript still follows the normal Groq plus Deepgram merge, clipboard, history, and validation path after recording stops.
+
+#### Soniox Provider Bypass
+
+When `liveDictation.soniox.enabled` is enabled, pressing `liveDictation.soniox.triggerKey` starts a Soniox real-time STT session. Recorder PCM is sent directly to Soniox, stable final tokens are typed into the focused input, and the final Soniox transcript is copied to clipboard and appended to history when recording stops.
+
+This path intentionally skips Groq, Deepgram batch transcription, merge, repair, and quality recovery. Use it when low-latency live dictation is more important than the normal multi-provider quality pipeline.
 
 #### Language Options
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -93,9 +93,11 @@ The configuration is a JSON file structured into several sections.
   "liveDictation": {
     "enabled": false,
     "insertionCommand": "auto",
+    "retypeFormatted": true,
     "soniox": {
       "enabled": false,
-      "triggerKey": "Right Alt"
+      "triggerKey": "Right Alt",
+      "paragraphPauseMs": 3000
     }
   }
 }
@@ -324,8 +326,12 @@ Live Dictation controls focused-text insertion while recording. It is disabled b
 | :--- | :--- | :--- | :--- | :--- |
 | `enabled` | Boolean | `false` | Type stable live transcript text into the currently focused input during the normal streaming path. | Requires `transcription.streaming: true` to receive Deepgram live transcript events. |
 | `insertionCommand` | String | `"auto"` | Command used for focused text insertion. | `"auto"`, `"wtype"`, or `"xdotool"`. |
+| `retypeFormatted` | Boolean | `true` | After stop, replace the typed text with the LLM-formatted version using Home + Shift+End selection. When off, formatted text only affects clipboard and history. | N/A |
 | `soniox.enabled` | Boolean | `false` | Enable the separate Soniox provider-bypass hotkey. | Requires `apiKeys.soniox` or `SONIOX_API_KEY` when used. |
 | `soniox.triggerKey` | String | `"Right Alt"` | Separate hotkey for Soniox live dictation. | Same hotkey format as `behavior.hotkey`. |
+| `soniox.paragraphPauseMs` | Number | `3000` | Minimum gap between consecutive Soniox token messages (in ms) before a paragraph break is inserted. | Integer `500`-`10000`. |
+| `retypeFormatted` | Boolean | `true` | After stop, replace typed text with LLM-formatted version (Home + Shift+End + retype). If false, formatting only affects clipboard/history. | N/A |
+| `soniox.paragraphPauseMs` | Number | `3000` | Minimum pause (ms) between Soniox token messages to trigger a paragraph break during live typing. | Integer `>= 500` |
 
 #### Normal Live Dictation
 
@@ -334,6 +340,8 @@ When `liveDictation.enabled` and `transcription.streaming` are both enabled, Hyp
 #### Soniox Provider Bypass
 
 When `liveDictation.soniox.enabled` is enabled, pressing `liveDictation.soniox.triggerKey` starts a Soniox real-time STT session. Recorder PCM is sent directly to Soniox, stable final tokens are typed into the focused input, and the final Soniox transcript is copied to clipboard and appended to history when recording stops.
+
+Tokens are joined with a single space; double spaces are collapsed and trailing spaces are trimmed. Paragraph breaks are inserted when the inter-token pause exceeds `soniox.paragraphPauseMs`. After stop, a minimal LLM pass adds paragraph breaks only — no rewriting. When `retypeFormatted` is true, the formatted text replaces what was typed via Home + Shift+End selection.
 
 This path intentionally skips Groq, Deepgram batch transcription, merge, repair, and quality recovery. Use it when low-latency live dictation is more important than the normal multi-provider quality pipeline.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -97,7 +97,13 @@ The configuration is a JSON file structured into several sections.
     "soniox": {
       "enabled": false,
       "triggerKey": "Right Alt",
-      "paragraphPauseMs": 3000
+      "paragraphPauseMs": 3000,
+      "languageHintsStrict": true,
+      "contextGeneral": [
+        { "key": "domain", "value": "software development" },
+        { "key": "topic", "value": "technical architecture and implementation" }
+      ],
+      "contextText": "The speaker is dictating technical prompts for AI coding agents, software architecture discussions, code comments, and developer workflow instructions. Content includes programming terminology, API references, database schemas, CLI commands, and system administration tasks."
     }
   }
 }
@@ -332,6 +338,9 @@ Live Dictation controls focused-text insertion while recording. It is disabled b
 | `soniox.paragraphPauseMs` | Number | `3000` | Minimum gap between consecutive Soniox token messages (in ms) before a paragraph break is inserted. | Integer `500`-`10000`. |
 | `retypeFormatted` | Boolean | `true` | After stop, replace typed text with LLM-formatted version (Home + Shift+End + retype). If false, formatting only affects clipboard/history. | N/A |
 | `soniox.paragraphPauseMs` | Number | `3000` | Minimum pause (ms) between Soniox token messages to trigger a paragraph break during live typing. | Integer `>= 500` |
+| `soniox.languageHintsStrict` | Boolean | `true` | Restrict Soniox transcription to only the languages specified in `language_hints`. Prevents language drift. | N/A |
+| `soniox.contextGeneral` | Array | Software dev metadata | Key-value pairs providing domain context to Soniox for improved recognition. | Array of `{key: string, value: string}` objects. |
+| `soniox.contextText` | String | Technical context | Free-form text (max 10,000 chars) describing the typical dictation content for Soniox context. | String, max 10,000 chars. |
 
 #### Normal Live Dictation
 

--- a/docs/ISSUES-LIVE-DICTATION-SONIOX.md
+++ b/docs/ISSUES-LIVE-DICTATION-SONIOX.md
@@ -1,0 +1,101 @@
+# Offline Issue Breakdown: Live Dictation And Soniox Provider Bypass
+
+## 1. Live Dictation Text Writer Contract
+
+**Type**: AFK
+
+**Blocked by**: None - can start immediately
+
+**User stories covered**: 1, 3, 4, 5, 6, 7, 8, 15, 18
+
+## What to build
+
+Build the smallest focused-input writer path that can accept stable transcript events and type only the committed delta into the currently focused field. The slice should include a command-backed text injection boundary with test doubles for command execution.
+
+## Acceptance criteria
+
+- [ ] Stable transcript chunks insert only new committed text.
+- [ ] Repeated transcript events do not duplicate already inserted text.
+- [ ] Wayland uses `wtype` by default when available.
+- [ ] X11 uses `xdotool type` when Wayland is not active.
+- [ ] Tests do not type into the real desktop.
+- [ ] Insertion errors are returned as structured failures that callers can log and recover from.
+
+## 2. Live Dictation Config And Readiness
+
+**Type**: AFK
+
+**Blocked by**: Issue 1
+
+**User stories covered**: 8, 9, 13, 14, 18
+
+## What to build
+
+Add configuration for Live Dictation and Soniox credentials without changing default transcription behavior. Readiness checks should report missing optional dependencies only when the feature is enabled.
+
+## Acceptance criteria
+
+- [ ] Existing minimal configs still parse and keep Live Dictation disabled by default.
+- [ ] Live Dictation config validates trigger key and insertion command settings.
+- [ ] Soniox credentials can be read from config or environment.
+- [ ] Missing Soniox credentials do not break default Groq plus Deepgram recording.
+- [ ] Tests cover config defaults, enabled Live Dictation config, and invalid trigger key handling.
+
+## 3. Live Provider Contract Around Existing Deepgram Streaming
+
+**Type**: AFK
+
+**Blocked by**: Issue 1
+
+**User stories covered**: 1, 2, 9, 16, 17, 18
+
+## What to build
+
+Introduce a live provider contract that represents streaming transcript events, PCM input, and final transcript stop behavior. Adapt the current Deepgram streaming path to that contract while preserving current default behavior.
+
+## Acceptance criteria
+
+- [ ] Normal streaming recordings still produce the same final clipboard behavior.
+- [ ] Live provider events can feed the Live Dictation text writer when enabled.
+- [ ] Deepgram streaming failures still fall back to existing batch behavior.
+- [ ] Tests prove the contract with a fake provider and do not call Deepgram.
+
+## 4. Soniox Provider Bypass Recording Path
+
+**Type**: AFK
+
+**Blocked by**: Issues 1, 2, 3
+
+**User stories covered**: 10, 11, 12, 13, 14, 16, 17, 18
+
+## What to build
+
+Add Soniox as a live provider and wire a separate provider-bypass trigger key. The path streams recorder PCM to Soniox, feeds stable transcript events to Live Dictation, and writes the final Soniox transcript to clipboard and history without running Groq, Deepgram batch, merge, repair, or quality recovery.
+
+## Acceptance criteria
+
+- [ ] Soniox provider connects to the documented real-time STT WebSocket endpoint.
+- [ ] Provider bypass does not call Groq, Deepgram batch, merge, repair, or quality recovery.
+- [ ] Final Soniox transcript is copied to clipboard and appended to history.
+- [ ] Provider errors surface as user-facing Soniox errors.
+- [ ] Tests use a fake WebSocket transport and do not hit Soniox.
+
+## 5. Runtime Verification And PR Readiness
+
+**Type**: HITL
+
+**Blocked by**: Issues 1, 2, 3, 4
+
+**User stories covered**: 1-18
+
+## What to build
+
+Run the focused local test suite, verify no default behavior changed, perform a manual live dictation check on the user machine, then prepare incremental commits and a PR.
+
+## Acceptance criteria
+
+- [ ] Focused unit tests pass.
+- [ ] Default config and normal transcription behavior remain unchanged.
+- [ ] Live Dictation can be manually tested in a scratch focused input.
+- [ ] Soniox provider bypass can be manually tested when credentials are available.
+- [ ] Commits are incremental and scoped to planning, infrastructure, provider contract, Soniox path, and verification.

--- a/docs/PRD-LIVE-DICTATION-SONIOX.md
+++ b/docs/PRD-LIVE-DICTATION-SONIOX.md
@@ -1,0 +1,77 @@
+# Live Dictation And Soniox Provider Bypass PRD
+
+## Problem Statement
+
+Hyprvox currently optimizes for final transcript quality: the user records, waits for provider results, receives a merged transcript, and then pastes from the clipboard. That is accurate, but it is not enough for workflows where the focused input should fill as the user speaks. The user also wants a low-latency Soniox live path that bypasses the existing Groq plus Deepgram merge pipeline while still copying the final transcript to the clipboard after the recording ends.
+
+## Solution
+
+Add Live Dictation as an explicit output mode. During an active recording, stable live transcript text is typed into the currently focused text field. When the recording stops, Hyprvox still writes the final transcript to clipboard and history.
+
+Add Soniox as a live transcription provider. Soniox provider bypass mode starts a recording through a separate trigger key, streams PCM to Soniox, types stable live transcript text into the focused text field, and copies the final Soniox transcript to the clipboard. It intentionally skips Groq, Deepgram batch transcription, merge, repair, and quality recovery.
+
+## User Stories
+
+1. As a Hyprvox user, I want dictated words to appear in the focused input while I speak, so that I do not have to wait until recording stops to see text.
+2. As a Hyprvox user, I want the final transcript copied to the clipboard after live dictation ends, so that my existing paste workflow still works.
+3. As a Hyprvox user, I want live text insertion to avoid duplicate partial phrases, so that the focused input remains readable.
+4. As a Hyprvox user, I want live insertion to type only stable transcript text, so that unstable interim provider guesses do not corrupt the input.
+5. As a Hyprvox user, I want live insertion to use the current focused text field, so that the feature works across editors, browsers, terminals, and chat inputs.
+6. As a Hyprvox user on Wayland, I want live insertion to use the available desktop text injection tool, so that the feature works in my normal Hyprland session.
+7. As a Hyprvox user on X11, I want a compatible text injection fallback, so that live dictation is not Wayland-only.
+8. As a Hyprvox user, I want live insertion failures to fall back to normal clipboard behavior, so that transcription is not lost.
+9. As a Hyprvox user, I want normal Groq plus Deepgram transcription to keep working unchanged unless live dictation is enabled, so that quality-critical recordings are not affected.
+10. As a Hyprvox user, I want a separate Soniox trigger key, so that I can choose a low-latency live provider without changing the default trigger key behavior.
+11. As a Hyprvox user, I want Soniox provider bypass to skip merge and quality recovery, so that the final transcript reflects the live provider directly with low latency.
+12. As a Hyprvox user, I want Soniox provider bypass to still write the final transcript to clipboard and history, so that downstream workflows remain consistent.
+13. As a Hyprvox user, I want Soniox authentication to be configured through Hyprvox config or environment variables, so that it behaves like the existing provider keys.
+14. As a Hyprvox user, I want Soniox provider errors to be reported clearly, so that I can distinguish auth, network, and runtime failures.
+15. As a Hyprvox maintainer, I want the live text writer to be tested independently from real desktop input, so that the behavior is stable without disrupting laptop usage.
+16. As a Hyprvox maintainer, I want provider bypass tests to exercise observable daemon behavior, so that refactors do not break the user-facing modes.
+17. As a Hyprvox maintainer, I want live provider implementations behind a small interface, so that Deepgram and Soniox streaming can share daemon orchestration without coupling to provider-specific SDK details.
+18. As a Hyprvox maintainer, I want benchmark thresholds for live insertion and stop latency, so that the feature has measurable quality gates.
+
+## Implementation Decisions
+
+- Keep normal recording semantics intact. The default trigger key continues to run the existing Groq plus Deepgram path unless the user explicitly enables Live Dictation for that path.
+- Introduce a Live Dictation output component that accepts transcript events and emits text insertion operations. It tracks committed text and only inserts stable deltas.
+- Treat provider interim text as display/input candidates and provider final text as committed text. Stable final chunks are the only text typed by default.
+- Use `wtype` as the primary Wayland focused-input writer because it is installed on the target machine and matches the Hyprland environment. Use `xdotool type` as an X11 fallback. Keep `ydotool` as a later fallback because it may require daemon permissions.
+- Add configuration for Live Dictation enablement, insertion command selection, and Soniox provider credentials.
+- Add a separate Soniox provider bypass trigger key. This mode has its own lifecycle but reuses audio capture, PCM streaming, clipboard output, history, notifications, and daemon state where practical.
+- Add a small live provider contract with start, send PCM, stop, and transcript events. Deepgram streaming can be adapted to that contract, and Soniox can implement the same contract.
+- Soniox provider bypass uses Soniox real-time STT over WebSocket. Current official docs describe real-time STT as WebSocket-based, with endpoint `wss://stt-rt.soniox.com`; the SDK reference exposes `wss://stt-rt.soniox.com/transcribe-websocket` as the default STT WebSocket URL.
+- Provider bypass final text is not sent through the Groq plus Deepgram merge result pipeline. It is copied as the Soniox final transcript and marked as provider bypass in history/metrics.
+- Keep GitHub issue publishing out of scope for the first planning artifact. Issues are drafted offline in this repository.
+
+## Testing Decisions
+
+- Tests should verify behavior through public interfaces and shell/system boundaries, not private methods.
+- Start with the Live Dictation text accumulator and text writer contract because it is the riskiest user-visible behavior and can be tested without real desktop input.
+- Mock only external boundaries: text injection command execution, WebSocket transport, and provider API responses.
+- Add focused tests for config parsing so Soniox and Live Dictation settings are validated without starting the daemon.
+- Add provider-bypass tests around a fake live provider to prove final transcript copy behavior without hitting Soniox.
+- Avoid local tests that open real microphones, real Electron windows, or real desktop notifications by default. Use existing `HYPRVOX_TEST_MODE=1` behavior and targeted unit tests first.
+
+## Benchmarks And Quality Gates
+
+- Live insertion latency: committed provider chunks should be scheduled for focused-input insertion within 100 ms of receipt in unit-level timing tests.
+- Duplication guard: repeated partial/final events must not insert duplicate words.
+- Stop-to-clipboard latency for provider bypass: no merge or batch provider call may run in the Soniox bypass path.
+- Normal path safety: default Groq plus Deepgram recording tests must not observe any Soniox dependency or live insertion side effect when the feature is disabled.
+- Desktop safety: automated tests must not type into the real desktop, send real notifications, or require real microphone input.
+- Config safety: missing Soniox credentials must fail only when Soniox bypass mode is used or explicitly verified, not when normal transcription runs.
+
+## Out of Scope
+
+- Replacing the Groq plus Deepgram merge result pipeline.
+- Streaming unstable interim text with later destructive edits in arbitrary inputs.
+- Overlay redesign.
+- Publishing PRD or issue drafts to GitHub before user approval.
+- Tuning endpointing or merge models for existing providers.
+- Supporting every desktop environment’s preferred text injection tool in the first slice.
+
+## Further Notes
+
+- Official Soniox references used for planning: `https://soniox.com/docs/api-reference/stt/websocket-api`, `https://soniox.com/docs/api-reference`, and `https://soniox.com/docs/stt/models`.
+- The term `Provider Bypass` is intentionally distinct from `Fallback`: fallback is an error recovery behavior, while provider bypass is a deliberate low-latency mode.

--- a/docs/PRD-SONIOX-LIVE-DICTATION-IMPROVEMENTS.md
+++ b/docs/PRD-SONIOX-LIVE-DICTATION-IMPROVEMENTS.md
@@ -1,0 +1,173 @@
+# Soniox Live Dictation Improvements PRD
+
+## Problem Statement
+
+The Soniox live dictation feature works end-to-end (Right Alt → WebSocket → text typing → clipboard), but the output quality is poor. Tokens are concatenated without spaces (`currentimplementation`), there are no paragraph breaks (everything is a wall of text), and no observability exists beyond `textLength`. The user cannot tell which words were recognized correctly, cannot read structured output, and has no way to debug tokenization issues.
+
+## Solution
+
+Fix token spacing, add pause-based paragraph breaks during live typing, add a minimal LLM formatting pass after stop (paragraph breaks only, no rewriting), add per-token debug logging, and add structured performance entries for statistical analysis. All new behavior is gated behind config options with safe defaults.
+
+## User Stories
+
+1. As a Hyprvox user, I want Soniox tokens to have proper word spacing, so that the typed text is readable.
+2. As a Hyprvox user, I want paragraph breaks to appear during live typing when I pause between topics, so that the typed text is structured.
+3. As a Hyprvox user, I want the LLM-formatted text to replace what was typed after recording stops, so that the final output has proper paragraph breaks.
+4. As a Hyprvox user, I want a config option to disable the retype behavior, so that I can use live dictation in contexts where retyping is risky (e.g., code editors with unsaved work).
+5. As a Hyprvox user, I want per-token debug logging when I set `LOG_LEVEL=debug`, so that I can diagnose tokenization and spacing issues.
+6. As a Hyprvox user, I want structured performance entries for Soniox sessions, so that I can track latency and token throughput over time.
+7. As a Hyprvox user, I want the paragraph pause threshold to be configurable, so that I can tune it for my speaking pace.
+8. As a Hyprvox user, I want the LLM formatting to only add paragraph breaks (no filler removal, no punctuation fixes, no rewriting), so that the output reflects what I actually said.
+9. As a Hyprvox maintainer, I want the LLM formatting to reuse the existing Groq/Llama infrastructure, so that no new API keys or dependencies are needed.
+10. As a Hyprvox maintainer, I want the retype mechanism to use Home + Shift+End (not Ctrl+A), so that it doesn't overwrite content outside the dictated text in code editors.
+11. As a Hyprvox maintainer, I want the paragraph break logic to be based on message-level timing gaps (not per-token timestamps), so that it works with Soniox's current token delivery model.
+12. As a Hyprvox maintainer, I want the `retypeFormatted` config option to default to `true`, so that most users get the formatted output without configuration.
+13. As a Hyprvox maintainer, I want the `paragraphPauseMs` config option to live inside `liveDictation.soniox`, so that it's clearly scoped to Soniox live dictation.
+14. As a Hyprvox maintainer, I want the LLM formatting pass to run asynchronously after the clipboard/history write, so that it doesn't block the user from continuing to work.
+15. As a Hyprvox maintainer, I want the retype mechanism to be a no-op if the focused window content has changed since dictation started, so that manual edits are not overwritten.
+
+## Implementation Decisions
+
+### Token Spacing
+
+Change `renderFinalTokenText` in `soniox-streaming.ts` to join tokens with a space instead of empty string, then collapse double spaces. This handles tokens that already include leading/trailing spaces (which Soniox produces) and tokens that don't (which currently run together).
+
+### Paragraph Break Insertion
+
+During live typing, track the time between consecutive `handleMessage` calls. If the gap exceeds `paragraphPauseMs` (default: 3000ms), insert a paragraph break before the delta. The break is typed as a double space (not `\n\n`) to avoid breaking single-line inputs.
+
+After the LLM formatting pass, the clipboard/history version gets proper `\n\n` paragraph breaks.
+
+### LLM Formatting Pass
+
+After `sonioxStreaming.stop()` returns the raw text, send it to Groq/Llama 3.3 with a minimal prompt:
+
+```
+Add paragraph breaks to this transcript at natural sentence boundaries.
+Do not change any words, punctuation, or formatting.
+Only insert blank lines between paragraphs where the topic changes.
+Return the formatted text only, no explanations.
+```
+
+The formatted text replaces the raw text for clipboard and history writes. If `retypeFormatted` is true, it also replaces what was typed in the focused window.
+
+### Retype Mechanism
+
+When `retypeFormatted` is true, after the LLM formats the text:
+1. Send `Home` to move cursor to start of line
+2. Send `Shift+End` to select the entire line (our typed text)
+3. Send the formatted text to replace the selection
+
+This avoids `Ctrl+A` which would select all content in the focused window (risky in code editors).
+
+### Config Schema Changes
+
+Add to `liveDictation.soniox`:
+- `paragraphPauseMs`: number, default 3000, minimum 1000. Milliseconds of silence between token messages before inserting a paragraph break.
+
+Add to `liveDictation`:
+- `retypeFormatted`: boolean, default true. When true, the LLM-formatted text replaces what was typed after recording stops.
+
+### Logging
+
+- Per-token debug logging: log each token's `text` and `is_final` flag at `debug` level in `handleMessage`.
+- Structured perf entry: emit `type: "perf"` with `engine: "soniox"`, `textLength`, `recordingDurationMs`, `processingMs`, `tokenCount`, `paragraphBreaksInserted`, `llmFormattingMs`.
+
+## Testing Decisions
+
+- Test `renderFinalTokenText` spacing with tokens that include/exclude leading/trailing spaces.
+- Test paragraph break insertion with mock `handleMessage` calls at various time intervals.
+- Test LLM formatting pass with mock Groq responses.
+- Test retype mechanism with mock `DesktopTextTyper` that records calls.
+- Test config schema validation for new fields.
+- Test that `retypeFormatted: false` skips the retype step.
+- Test that `paragraphPauseMs` below minimum is clamped.
+- Avoid real desktop typing, real microphone input, or real API calls in unit tests.
+
+## Out of Scope
+
+- Interim token preview (showing partial words before they commit).
+- Self-correction backspacing (detecting and undoing mistakes).
+- Filler word removal ("um", "uh", "like").
+- Punctuation fixing or grammar correction.
+- Sentence restructuring or rewriting.
+- Per-token confidence scoring (Soniox doesn't expose this in the current interface).
+- Overlay changes for Soniox sessions.
+- Deepgram streaming paragraph breaks (has its own `speech_final` mechanism).
+
+## Implementation Status
+
+| Item | Status |
+|------|--------|
+| Token spacing (join with space, collapse doubles) | Done |
+| Per-token debug logging | Done |
+| Structured perf entries | Done |
+| `paragraphPauseMs` config schema | Done |
+| Paragraph break insertion (double-space prefix) | Done |
+| LLM formatting pass (Groq/Llama 3.3) | Done |
+| `retypeFormatted` config + Home+Shift+End retype | Done |
+| Tests (9 Soniox-specific, 245 total) | Done |
+| Documentation updates | Done |
+
+## Implementation Status
+
+| Item | Status |
+|------|--------|
+| Token spacing (join with space, collapse doubles) | Done |
+| Per-token debug logging | Done |
+| Structured perf entries | Done |
+| `paragraphPauseMs` config schema | Done |
+| Paragraph break insertion (double-space prefix) | Done |
+| LLM formatting pass (Groq/Llama 3.3) | Done |
+| `retypeFormatted` config + Home+Shift+End retype | Done |
+| Tests (9 Soniox-specific, 245 total) | Done |
+| Documentation updates | Done |
+
+## Implementation Status
+
+| Item | Status |
+|------|--------|
+| Token spacing (join with space, collapse doubles) | Done |
+| Per-token debug logging | Done |
+| Structured perf entries | Done |
+| `paragraphPauseMs` config schema | Done |
+| Paragraph break insertion (double-space prefix) | Done |
+| LLM formatting pass (Groq/Llama 3.3) | Done |
+| `retypeFormatted` config + Home+Shift+End retype | Done |
+| Tests (9 Soniox-specific, 245 total) | Done |
+| Documentation updates | Done |
+
+## Implementation Status
+
+| Item | Status |
+|------|--------|
+| Token spacing (join with space, collapse doubles) | Done |
+| Per-token debug logging | Done |
+| Structured perf entries | Done |
+| `paragraphPauseMs` config schema | Done |
+| Paragraph break insertion (double-space prefix) | Done |
+| LLM formatting pass (Groq/Llama 3.3) | Done |
+| `retypeFormatted` config + Home+Shift+End retype | Done |
+| Tests (9 Soniox-specific, 245 total) | Done |
+| Documentation updates | Done |
+
+## Implementation Status
+
+| Item | Status |
+|------|--------|
+| Token spacing (join with space, collapse doubles) | Done |
+| Per-token debug logging | Done |
+| Structured perf entries | Done |
+| `paragraphPauseMs` config schema | Done |
+| Paragraph break insertion (double-space prefix) | Done |
+| LLM formatting pass (Groq/Llama 3.3) | Done |
+| `retypeFormatted` config + Home+Shift+End retype | Done |
+| Tests (9 Soniox-specific, 245 total) | Done |
+| Documentation updates | Done |
+
+## Further Notes
+
+- This PRD builds on the existing `PRD-LIVE-DICTATION-SONIOX.md` which defined the core Soniox provider bypass feature.
+- The LLM formatting pass is deliberately minimal — it adds paragraph breaks only, preserving the speaker's exact words and punctuation.
+- The `retypeFormatted` default is `true` because most users expect the final output to be formatted. Users who need the raw text can set it to `false`.
+- The paragraph pause threshold of 3000ms is a starting point — it should be tuned based on real usage data.

--- a/docs/STT_FLOW.md
+++ b/docs/STT_FLOW.md
@@ -103,6 +103,25 @@ Live Dictation is an opt-in output path for committed streaming transcript chunk
 - In Soniox provider bypass mode, `liveDictation.soniox.triggerKey` starts a Soniox real-time WebSocket session. Recorder PCM is sent directly as 16 kHz mono `pcm_s16le`, final Soniox tokens are typed into the focused input, and the final Soniox transcript is copied to clipboard and history when recording stops.
 - Soniox provider bypass intentionally skips Groq, Deepgram batch transcription, merge, repair, and quality recovery. The history engine is recorded as `soniox`, and aggregate performance logs use `mergeStrategy: "provider_bypass"`.
 
+#### Soniox Formatting Pipeline
+
+Tokens arriving from Soniox are joined with a single space; double spaces are collapsed and trailing spaces are trimmed. When the pause between consecutive Soniox token messages exceeds `liveDictation.soniox.paragraphPauseMs` (default: 3000ms), a paragraph break is inserted as a double-space prefix to the next token. Only final tokens are emitted — interim/partial tokens are discarded to avoid flickering. Self-corrections are not backspaced; mistakes remain in the typed text and can be corrected manually after recording stops.
+
+After stop, a minimal Groq/Llama 3.3 pass runs over the Soniox transcript. This pass adds only paragraph breaks at natural sentence boundaries — it does not remove filler, fix punctuation, or rewrite content. When `liveDictation.retypeFormatted` is true (default), the LLM-formatted text replaces what was typed using Home + Shift+End selection followed by a retype, avoiding Ctrl+A risk in editors. When off, the formatted text only affects clipboard and history.
+
+Per-token debug logging is available at `LOG_LEVEL=debug`. Structured perf entries (`type: "perf"`) include `paragraphBreakCount` and `llmFormattingMs` for statistical analysis.
+
+#### Soniox Formatting Pipeline
+
+After recording stops, the Soniox transcript goes through a lightweight formatting pipeline:
+
+1. **Token spacing**: Final tokens are joined with a single space; double spaces are collapsed and trailing spaces are trimmed.
+2. **Paragraph breaks**: When the pause between consecutive Soniox token messages exceeds `liveDictation.soniox.paragraphPauseMs` (default: 3000ms), a paragraph break is inserted as a double-space prefix to the next token.
+3. **LLM formatting pass** (if `liveDictation.retypeFormatted` is true): A minimal Groq/Llama 3.3 call adds paragraph breaks at natural sentence boundaries — no filler removal, no punctuation fixes, no rewriting.
+4. **Retype**: If `retypeFormatted` is true, the LLM-formatted text replaces what was typed using Home + Shift+End selection + retype (avoiding Ctrl+A risk in editors). If off, formatting only affects clipboard/history.
+
+Per-token debug logging is available at `LOG_LEVEL=debug`. Structured perf entries (`type: "perf"`) include `paragraphBreakCount` and `llmFormattingMs`.
+
 ### 5. Merge And Quality Pipeline
 If both Groq and Deepgram return results, Hyprvox first decides whether deterministic selection is enough or whether an LLM merge is needed. The merge model is configured by `transcription.mergeModel`.
 

--- a/docs/STT_FLOW.md
+++ b/docs/STT_FLOW.md
@@ -49,6 +49,7 @@ sequenceDiagram
 - **Key**: Default is `Right Control`.
 - **Behavior**: Toggle mode. The first press starts the recording; the second press stops it.
 - **Verification**: Checks for hotkey conflicts at startup.
+- **Soniox bypass**: If `liveDictation.soniox.enabled` is true, `liveDictation.soniox.triggerKey` starts a separate Soniox live dictation path instead of the normal Groq plus Deepgram path.
 
 ### 2. Audio Capture
 - **Utility**: `arecord` (via `node-record-lpcm16`).
@@ -93,6 +94,14 @@ Before provider calls, the daemon builds technical-term hints from configured bo
 **Deepgram Finalization Metrics**: In streaming mode, each session records `deepgramFinalizeWaitMs`, `deepgramCloseWaitMs`, `deepgramEndpointingMs`, `deepgramReceivedFinalChunk`, and `deepgramHadSpeechFinal`. These explain whether stop latency came from waiting for the final transcript, closing the WebSocket, or missing Deepgram finalization signals.
 
 **Live Groq Chunk Metrics**: Live chunking perf events include chunk counts, finalize wait, final-tail length, background request time, dropped/recovered chunk counts, and quality fallback status. `groqLiveDroppedChunks` tracks chunk-local outputs removed before stitching; `groqLiveRecoveredChunks` tracks dropped chunks recovered by contextual repair; `groqLiveQualityFallback` records when a clean-looking live Groq transcript was materially shorter than Deepgram and Hyprvox ran one full-audio Groq request before merge.
+
+### 4b. Live Dictation And Soniox Provider Bypass
+
+Live Dictation is an opt-in output path for committed streaming transcript chunks:
+
+- In the normal path, `liveDictation.enabled` plus `transcription.streaming` types committed Deepgram transcript chunks into the focused input while recording continues. Stop still runs the normal Groq plus Deepgram merge, validation, clipboard, and history flow.
+- In Soniox provider bypass mode, `liveDictation.soniox.triggerKey` starts a Soniox real-time WebSocket session. Recorder PCM is sent directly as 16 kHz mono `pcm_s16le`, final Soniox tokens are typed into the focused input, and the final Soniox transcript is copied to clipboard and history when recording stops.
+- Soniox provider bypass intentionally skips Groq, Deepgram batch transcription, merge, repair, and quality recovery. The history engine is recorded as `soniox`, and aggregate performance logs use `mergeStrategy: "provider_bypass"`.
 
 ### 5. Merge And Quality Pipeline
 If both Groq and Deepgram return results, Hyprvox first decides whether deterministic selection is enough or whether an LLM merge is needed. The merge model is configured by `transcription.mergeModel`.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -305,6 +305,41 @@ program
 	});
 
 program
+	.command("soniox-toggle")
+	.description("Toggle Soniox live dictation (start/stop)")
+	.action(async () => {
+		const socketPath = join(
+			homedir(),
+			".config",
+			"hypr",
+			"vox",
+			"daemon.sock",
+		);
+		if (!existsSync(socketPath)) {
+			console.error(colors.red("Error: Daemon is not running."));
+			console.log(`Start it with: ${colors.cyan("hyprvox start")}`);
+			process.exit(1);
+		}
+
+		const { createConnection } = await import("node:net");
+		const client = createConnection({ path: socketPath });
+
+		client.on("connect", () => {
+			client.write(
+				JSON.stringify({ type: "action", action: "soniox-toggle" }) + "\n",
+			);
+			console.log(colors.green("✅") + " Soniox toggle sent to daemon");
+			client.destroy();
+			process.exit(0);
+		});
+
+		client.on("error", (err) => {
+			console.error(colors.red("Failed to reach daemon:"), err.message);
+			process.exit(1);
+		});
+	});
+
+program
 	.command("install")
 	.description("Install systemd service")
 	.action(() => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -128,6 +128,7 @@ export const loadConfig = (
 			groq: process.env.GROQ_API_KEY,
 			groqFallback: process.env.GROQ_FALLBACK_API_KEY,
 			deepgram: process.env.DEEPGRAM_API_KEY,
+			soniox: process.env.SONIOX_API_KEY,
 		},
 	};
 
@@ -144,6 +145,7 @@ export const loadConfig = (
 				envConfig.apiKeys.groqFallback,
 			deepgram:
 				parsedFileConfig.apiKeys?.deepgram ?? envConfig.apiKeys.deepgram,
+			soniox: parsedFileConfig.apiKeys?.soniox ?? envConfig.apiKeys.soniox,
 		},
 		// Other sections are handled by Zod defaults if missing
 	};

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -212,6 +212,15 @@ const defaultAudio = {
 	compressionThreshold: 1048576, // 1MB in bytes (~32 seconds of audio)
 };
 
+const defaultLiveDictation = {
+	enabled: false,
+	insertionCommand: "auto" as const,
+	soniox: {
+		enabled: false,
+		triggerKey: "Right Alt",
+	},
+};
+
 export const ApiKeysSchema = z.object({
 	groq: z
 		.string()
@@ -225,6 +234,10 @@ export const ApiKeysSchema = z.object({
 		.min(10, { message: "Fallback Groq API key is too short" })
 		.optional(),
 	deepgram: DeepgramApiKeySchema,
+	soniox: z
+		.string()
+		.min(1, { message: "Soniox API key is too short" })
+		.optional(),
 });
 
 export const ApiKeysFileSchema = ApiKeysSchema.partial().refine(
@@ -402,6 +415,27 @@ export const AudioSchema = z
 	})
 	.default(defaultAudio);
 
+export const LiveDictationSchema = z
+	.object({
+		enabled: z.boolean().default(defaultLiveDictation.enabled),
+		insertionCommand: z
+			.enum(["auto", "wtype", "xdotool"])
+			.default(defaultLiveDictation.insertionCommand),
+		soniox: z
+			.object({
+				enabled: z.boolean().default(defaultLiveDictation.soniox.enabled),
+				triggerKey: z
+					.string()
+					.default(defaultLiveDictation.soniox.triggerKey)
+					.refine(hotkeyValidator, {
+						message:
+							"Invalid Soniox trigger key format. Use 'Modifier+Key' (e.g., 'Ctrl+Space', 'Right Alt').",
+					}),
+			})
+			.default(defaultLiveDictation.soniox),
+	})
+	.default(defaultLiveDictation);
+
 export const ConfigSchema = z.object({
 	apiKeys: ApiKeysSchema,
 	behavior: BehaviorSchema.default(defaultBehavior),
@@ -409,6 +443,7 @@ export const ConfigSchema = z.object({
 	transcription: TranscriptionSchema.default(defaultTranscription),
 	overlay: OverlaySchema,
 	audio: AudioSchema,
+	liveDictation: LiveDictationSchema,
 });
 
 export const ConfigFileSchema = z.object({
@@ -418,6 +453,7 @@ export const ConfigFileSchema = z.object({
 	transcription: TranscriptionSchema.default(defaultTranscription),
 	overlay: OverlaySchema,
 	audio: AudioSchema,
+	liveDictation: LiveDictationSchema,
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -215,11 +215,17 @@ const defaultAudio = {
 const defaultLiveDictation = {
 	enabled: false,
 	insertionCommand: "auto" as const,
-	retypeFormatted: true,
+	retypeFormatted: false,
 	soniox: {
 		enabled: false,
 		triggerKey: "Right Alt",
 		paragraphPauseMs: 3000,
+		languageHintsStrict: true,
+		contextGeneral: [
+			{ key: "domain", value: "software development" },
+			{ key: "topic", value: "technical architecture and implementation" },
+		],
+		contextText: "The speaker is dictating technical prompts for AI coding agents, software architecture discussions, code comments, and developer workflow instructions. Content includes programming terminology, API references, database schemas, CLI commands, and system administration tasks.",
 	},
 };
 
@@ -438,6 +444,21 @@ export const LiveDictationSchema = z
 					.number()
 					.min(1000, { message: "paragraphPauseMs must be at least 1000ms" })
 					.default(defaultLiveDictation.soniox.paragraphPauseMs),
+				languageHintsStrict: z
+					.boolean()
+					.default(defaultLiveDictation.soniox.languageHintsStrict),
+				contextGeneral: z
+					.array(
+						z.object({
+							key: z.string(),
+							value: z.string(),
+						}),
+					)
+					.default(defaultLiveDictation.soniox.contextGeneral),
+				contextText: z
+					.string()
+					.max(10000, { message: "contextText must be at most 10000 characters" })
+					.default(defaultLiveDictation.soniox.contextText),
 			})
 			.default(defaultLiveDictation.soniox),
 	})

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -215,9 +215,11 @@ const defaultAudio = {
 const defaultLiveDictation = {
 	enabled: false,
 	insertionCommand: "auto" as const,
+	retypeFormatted: true,
 	soniox: {
 		enabled: false,
 		triggerKey: "Right Alt",
+		paragraphPauseMs: 3000,
 	},
 };
 
@@ -421,6 +423,7 @@ export const LiveDictationSchema = z
 		insertionCommand: z
 			.enum(["auto", "wtype", "xdotool"])
 			.default(defaultLiveDictation.insertionCommand),
+		retypeFormatted: z.boolean().default(defaultLiveDictation.retypeFormatted),
 		soniox: z
 			.object({
 				enabled: z.boolean().default(defaultLiveDictation.soniox.enabled),
@@ -431,6 +434,10 @@ export const LiveDictationSchema = z
 						message:
 							"Invalid Soniox trigger key format. Use 'Modifier+Key' (e.g., 'Ctrl+Space', 'Right Alt').",
 					}),
+				paragraphPauseMs: z
+					.number()
+					.min(1000, { message: "paragraphPauseMs must be at least 1000ms" })
+					.default(defaultLiveDictation.soniox.paragraphPauseMs),
 			})
 			.default(defaultLiveDictation.soniox),
 	})

--- a/src/daemon/hotkey.ts
+++ b/src/daemon/hotkey.ts
@@ -4,81 +4,144 @@ import {
 	type IGlobalKeyEvent,
 } from "node-global-key-listener";
 import { loadConfig } from "../config/loader";
+import type { Config } from "../config/schema";
 import { notify } from "../output/notification";
 import { logError, logger } from "../utils/logger";
+
+export interface HotkeyBinding {
+	id: "default" | "soniox";
+	hotkey: string;
+	event: "trigger" | "soniox-trigger";
+	triggerKey: string;
+	modifiers: string[];
+}
+
+export function createHotkeyBindings(
+	config: Pick<Config, "behavior" | "liveDictation">,
+): HotkeyBinding[] {
+	const bindings: HotkeyBinding[] = [];
+	const defaultBinding = parseHotkeyBinding(
+		"default",
+		config.behavior.hotkey,
+		"trigger",
+	);
+	if (defaultBinding) {
+		bindings.push(defaultBinding);
+	}
+
+	if (config.liveDictation.soniox.enabled) {
+		const sonioxBinding = parseHotkeyBinding(
+			"soniox",
+			config.liveDictation.soniox.triggerKey,
+			"soniox-trigger",
+		);
+		if (sonioxBinding) {
+			bindings.push(sonioxBinding);
+		}
+	}
+
+	return bindings;
+}
+
+export function matchesHotkeyBinding(
+	binding: HotkeyBinding,
+	keyName: string | undefined,
+	down: Record<string, boolean>,
+): boolean {
+	const normalizedKeyName = keyName?.toUpperCase().replace("CONTROL", "CTRL");
+	if (normalizedKeyName !== binding.triggerKey) {
+		return false;
+	}
+
+	return binding.modifiers.every((mod) => {
+		if (mod === "CTRL" || mod === "CONTROL") {
+			return (
+				down["LEFT CTRL"] ||
+				down["RIGHT CTRL"] ||
+				down["LEFT CONTROL"] ||
+				down["RIGHT CONTROL"]
+			);
+		}
+		if (mod === "ALT") return down["LEFT ALT"] || down["RIGHT ALT"];
+		if (mod === "SHIFT") return down["LEFT SHIFT"] || down["RIGHT SHIFT"];
+		if (mod === "META" || mod === "SUPER" || mod === "WIN") {
+			return (
+				down["LEFT META"] ||
+				down["RIGHT META"] ||
+				down["LEFT WIN"] ||
+				down["RIGHT WIN"]
+			);
+		}
+
+		return down[mod];
+	});
+}
+
+function parseHotkeyBinding(
+	id: HotkeyBinding["id"],
+	hotkey: string,
+	event: HotkeyBinding["event"],
+): HotkeyBinding | null {
+	const normalizedHotkey = hotkey.toUpperCase();
+	if (normalizedHotkey === "DISABLED") {
+		return null;
+	}
+
+	const parts = normalizedHotkey.split("+").map((p) => p.trim());
+	const triggerKeyRaw = parts[parts.length - 1];
+	if (!triggerKeyRaw) {
+		return null;
+	}
+
+	return {
+		id,
+		hotkey: normalizedHotkey,
+		event,
+		triggerKey: triggerKeyRaw.replace("CONTROL", "CTRL"),
+		modifiers: parts.slice(0, parts.length - 1),
+	};
+}
 
 export class HotkeyListener extends EventEmitter {
 	private listener: GlobalKeyboardListener | null = null;
 	private registered = false;
-	private isPressed = false;
+	private pressedBindings = new Set<HotkeyBinding["id"]>();
 
 	public start() {
 		if (this.registered) return;
 
 		try {
 			const config = loadConfig();
-			const hotkey = config.behavior.hotkey.toUpperCase();
+			const bindings = createHotkeyBindings(config);
 
-			if (hotkey === "DISABLED") {
+			if (bindings.length === 0) {
 				logger.info("Hotkey listener is disabled in configuration");
-				return;
-			}
-
-			const parts = hotkey.split("+").map((p) => p.trim());
-			const triggerKeyRaw = parts[parts.length - 1];
-			if (!triggerKeyRaw) {
-				const msg = "Invalid hotkey configuration: empty trigger key";
-				logger.warn(msg);
-				notify("Configuration Error", msg, "error");
 				return;
 			}
 
 			this.listener = new GlobalKeyboardListener();
 
-			const modifiers = parts.slice(0, parts.length - 1);
-
-			const triggerKey = triggerKeyRaw.replace("CONTROL", "CTRL");
-
 			this.listener.addListener(
 				(e: IGlobalKeyEvent, down: Record<string, boolean>) => {
 					const keyName = e.name?.toUpperCase();
-					const normalizedKeyName = keyName?.replace("CONTROL", "CTRL");
 
 					if (e.state === "DOWN") {
-						if (normalizedKeyName === triggerKey) {
-							const allModifiersPressed = modifiers.every((mod) => {
-								if (mod === "CTRL" || mod === "CONTROL")
-									return (
-										down["LEFT CTRL"] ||
-										down["RIGHT CTRL"] ||
-										down["LEFT CONTROL"] ||
-										down["RIGHT CONTROL"]
-									);
-								if (mod === "ALT") return down["LEFT ALT"] || down["RIGHT ALT"];
-								if (mod === "SHIFT")
-									return down["LEFT SHIFT"] || down["RIGHT SHIFT"];
-								if (mod === "META" || mod === "SUPER" || mod === "WIN")
-									return (
-										down["LEFT META"] ||
-										down["RIGHT META"] ||
-										down["LEFT WIN"] ||
-										down["RIGHT WIN"]
-									);
-
-								return down[mod];
-							});
-
-							if (allModifiersPressed) {
-								if (!this.isPressed) {
-									this.isPressed = true;
-									logger.info(`Hotkey triggered: ${hotkey}`);
-									this.emit("trigger");
-								}
+						for (const binding of bindings) {
+							if (
+								matchesHotkeyBinding(binding, keyName, down) &&
+								!this.pressedBindings.has(binding.id)
+							) {
+								this.pressedBindings.add(binding.id);
+								logger.info(`Hotkey triggered: ${binding.hotkey}`);
+								this.emit(binding.event);
 							}
 						}
 					} else if (e.state === "UP") {
-						if (normalizedKeyName === triggerKey) {
-							this.isPressed = false;
+						const normalizedKeyName = keyName?.replace("CONTROL", "CTRL");
+						for (const binding of bindings) {
+							if (normalizedKeyName === binding.triggerKey) {
+								this.pressedBindings.delete(binding.id);
+							}
 						}
 					}
 				},

--- a/src/daemon/ipc.ts
+++ b/src/daemon/ipc.ts
@@ -20,12 +20,13 @@ export const SOCKET_PATH = join(
 	"daemon.sock",
 );
 
-export type { DaemonStatus, IPCMessage } from "../shared/ipc-types";
+export type { DaemonStatus, IPCMessage, ActionMessage } from "../shared/ipc-types";
 
 export interface IPCServerEvents {
 	clientConnected: (clientId: number) => void;
 	clientDisconnected: (clientId: number) => void;
 	error: (error: Error) => void;
+	command: (action: string) => void;
 }
 
 type StateIPCMessage = Extract<IPCMessage, { type: "hello" | "state" }>;
@@ -159,6 +160,9 @@ export class IPCServer extends EventEmitter {
 				for (const line of lines) {
 					const msg = JSON.parse(line);
 					logger.debug({ clientId, msg }, "Received message from client");
+					if (msg.type === "action" && typeof msg.action === "string") {
+						this.emit("command", msg.action);
+					}
 				}
 			} catch {
 				// Malformed JSON - ignore

--- a/src/daemon/recording-session.ts
+++ b/src/daemon/recording-session.ts
@@ -6,6 +6,7 @@ import type { GroqSingleFileTranscriber } from "../transcribe/groq-chunking";
 import { GroqLiveChunkSession } from "../transcribe/groq-live-chunking";
 import {
 	isCommittedLiveTranscript,
+	type LiveStreamingProvider,
 	type LiveTranscriptEvent,
 } from "../transcribe/live-provider";
 import { logError, logger } from "../utils/logger";
@@ -25,6 +26,7 @@ interface CreateLiveGroqSessionInput {
 interface AttachStreamingPcmHandlerInput {
 	recorder: AudioRecorder;
 	deepgramStreaming?: DeepgramStreamingTranscriber;
+	liveProvider?: LiveStreamingProvider;
 	liveGroqSession?: GroqLiveChunkSession;
 }
 
@@ -132,6 +134,7 @@ export function attachStreamingPcmHandler(
 	input: AttachStreamingPcmHandlerInput,
 ): (payload: PcmAudioPayload) => void {
 	const { recorder, deepgramStreaming, liveGroqSession } = input;
+	const liveProvider = input.liveProvider ?? deepgramStreaming;
 	let chunkCount = 0;
 	const handler = (payload: PcmAudioPayload) => {
 		chunkCount++;
@@ -139,7 +142,7 @@ export function attachStreamingPcmHandler(
 			{ chunkNumber: chunkCount, chunkSize: payload.pcm.length },
 			"Handler called with PCM chunk",
 		);
-		deepgramStreaming?.send(payload.pcm);
+		liveProvider?.send(payload.pcm);
 		if (deepgramStreaming) {
 			logger.debug({ chunkNumber: chunkCount }, "Sent chunk to Deepgram");
 		}

--- a/src/daemon/recording-session.ts
+++ b/src/daemon/recording-session.ts
@@ -92,7 +92,7 @@ export function startDeepgramStreaming(
 
 export function attachLiveDictationTranscriptHandler(
 	input: AttachLiveDictationTranscriptHandlerInput,
-): () => void {
+): { detach: () => void; writer: LiveDictationWriter } {
 	const { provider, typer } = input;
 	const writer = new LiveDictationWriter(typer);
 	let pendingWrite = Promise.resolve();
@@ -110,8 +110,11 @@ export function attachLiveDictationTranscriptHandler(
 	};
 
 	provider.on("transcript", handler);
-	return () => {
-		provider.off("transcript", handler);
+	return {
+		detach: () => {
+			provider.off("transcript", handler);
+		},
+		writer,
 	};
 }
 

--- a/src/daemon/recording-session.ts
+++ b/src/daemon/recording-session.ts
@@ -1,8 +1,13 @@
 import type { AudioRecorder, PcmAudioPayload } from "../audio/recorder";
 import type { Config } from "../config/schema";
-import type { GroqSingleFileTranscriber } from "../transcribe/groq-chunking";
+import { LiveDictationWriter, type TextTyper } from "../output/live-dictation";
 import { DeepgramStreamingTranscriber } from "../transcribe/deepgram-streaming";
+import type { GroqSingleFileTranscriber } from "../transcribe/groq-chunking";
 import { GroqLiveChunkSession } from "../transcribe/groq-live-chunking";
+import {
+	isCommittedLiveTranscript,
+	type LiveTranscriptEvent,
+} from "../transcribe/live-provider";
 import { logError, logger } from "../utils/logger";
 
 interface StartDeepgramStreamingInput {
@@ -21,6 +26,22 @@ interface AttachStreamingPcmHandlerInput {
 	recorder: AudioRecorder;
 	deepgramStreaming?: DeepgramStreamingTranscriber;
 	liveGroqSession?: GroqLiveChunkSession;
+}
+
+interface TranscriptEventSource {
+	on(
+		event: "transcript",
+		listener: (text: string, event: LiveTranscriptEvent) => void,
+	): unknown;
+	off(
+		event: "transcript",
+		listener: (text: string, event: LiveTranscriptEvent) => void,
+	): unknown;
+}
+
+interface AttachLiveDictationTranscriptHandlerInput {
+	provider: TranscriptEventSource;
+	typer: TextTyper;
 }
 
 export async function stopDeepgramStreaming(
@@ -65,6 +86,31 @@ export function startDeepgramStreaming(
 	});
 	logger.info("Deepgram streaming initiated (background)");
 	return deepgramStreaming;
+}
+
+export function attachLiveDictationTranscriptHandler(
+	input: AttachLiveDictationTranscriptHandlerInput,
+): () => void {
+	const { provider, typer } = input;
+	const writer = new LiveDictationWriter(typer);
+	let pendingWrite = Promise.resolve();
+
+	const handler = (_text: string, event: LiveTranscriptEvent) => {
+		if (!isCommittedLiveTranscript(event)) {
+			return;
+		}
+
+		pendingWrite = pendingWrite
+			.then(() => writer.acceptCommittedTranscript(event.text))
+			.catch((error) => {
+				logError("Failed to type live dictation transcript", error);
+			});
+	};
+
+	provider.on("transcript", handler);
+	return () => {
+		provider.off("transcript", handler);
+	};
 }
 
 export function createLiveGroqSession(

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -33,6 +33,7 @@ import { assessLongRecordingQuality } from "../transcribe/long-recording";
 import { type MergeResult, TranscriptMerger } from "../transcribe/merger";
 import { validateTranscript } from "../transcribe/quality";
 import { recoverTranscriptQuality } from "../transcribe/recovery";
+import { SonioxStreamingTranscriber } from "../transcribe/soniox-streaming";
 import { ErrorTemplates, formatUserError } from "../utils/error-templates";
 import { errorIncludes, getErrorCode } from "../utils/errors";
 import { appendHistory } from "../utils/history";
@@ -104,9 +105,11 @@ export class DaemonService {
 	private groq: GroqClient;
 	private deepgram: DeepgramTranscriber;
 	private deepgramStreaming?: DeepgramStreamingTranscriber;
+	private sonioxStreaming?: SonioxStreamingTranscriber;
 	private streamingPcmHandler?: (payload: PcmAudioPayload) => void;
 	private liveDictationTranscriptDetach?: () => void;
 	private liveGroqSession?: GroqLiveChunkSession;
+	private recordingMode: "standard" | "soniox" = "standard";
 	private merger: TranscriptMerger;
 	private clipboard: ClipboardManager;
 	private pidFile: string;
@@ -330,6 +333,7 @@ export class DaemonService {
 
 	private setupListeners() {
 		this.hotkeyListener.on("trigger", () => this.handleTrigger());
+		this.hotkeyListener.on("soniox-trigger", () => this.handleSonioxTrigger());
 
 		this.recorder.on("start", () => {
 			this.lastOverlayAudioLevelAt = 0;
@@ -342,6 +346,14 @@ export class DaemonService {
 			this.lastOverlayAudioLevelAt = 0;
 			this.smoothedOverlayLevel = 0;
 			this.setStatus("processing");
+			if (this.recordingMode === "soniox") {
+				this.notifyStateChange(
+					"Soniox Recording Stopped",
+					"Finalizing live transcription...",
+				);
+				this.processSonioxAudio(duration);
+				return;
+			}
 			this.notifyStateChange(
 				"Recording Stopped",
 				"Processing transcription...",
@@ -407,15 +419,24 @@ export class DaemonService {
 			this.updateState();
 			this.overlay.start();
 
-			const hotkeyDisabled =
+			const defaultHotkeyDisabled =
 				this.config.behavior.hotkey.toLowerCase() === "disabled";
+			const anyHotkeyEnabled =
+				!defaultHotkeyDisabled || this.config.liveDictation.soniox.enabled;
 
 			const isWayland =
 				!!process.env.WAYLAND_DISPLAY ||
 				process.env.XDG_SESSION_TYPE === "wayland";
 
-			if (!hotkeyDisabled) {
-				await checkHotkeyConflict(this.config.behavior.hotkey);
+			if (anyHotkeyEnabled) {
+				if (!defaultHotkeyDisabled) {
+					await checkHotkeyConflict(this.config.behavior.hotkey);
+				}
+				if (this.config.liveDictation.soniox.enabled) {
+					await checkHotkeyConflict(
+						this.config.liveDictation.soniox.triggerKey,
+					);
+				}
 				this.hotkeyListener.start();
 				logger.info("Daemon started. Waiting for hotkey...");
 
@@ -480,6 +501,14 @@ export class DaemonService {
 		}
 		await stopDeepgramStreaming(this.deepgramStreaming, reason);
 		this.deepgramStreaming = undefined;
+		if (this.sonioxStreaming) {
+			try {
+				await this.sonioxStreaming.stop();
+			} catch (error: unknown) {
+				logError(reason, error);
+			}
+			this.sonioxStreaming = undefined;
+		}
 		if (this.liveGroqSession) {
 			this.liveGroqSession.cancel();
 			this.liveGroqSession = undefined;
@@ -488,6 +517,7 @@ export class DaemonService {
 
 	private async handleTrigger() {
 		if (this.status === "idle" || this.status === "error") {
+			this.recordingMode = "standard";
 			this.cancelPending = false;
 			try {
 				this.setStatus("starting");
@@ -590,6 +620,146 @@ export class DaemonService {
 			notify("Cancelled", "Recording start cancelled", "info");
 		} else {
 			logger.warn(`Hotkey ignored in state: ${this.status}`);
+		}
+	}
+
+	private async handleSonioxTrigger() {
+		if (!this.config.liveDictation.soniox.enabled) {
+			logger.warn("Soniox trigger ignored because Soniox bypass is disabled");
+			return;
+		}
+
+		if (this.status === "idle" || this.status === "error") {
+			this.recordingMode = "soniox";
+			this.cancelPending = false;
+			try {
+				this.setStatus("starting");
+				this.sonioxStreaming = new SonioxStreamingTranscriber();
+				this.sonioxStreaming.on("error", (error) => {
+					logError("Soniox streaming error", error);
+				});
+				this.liveDictationTranscriptDetach =
+					attachLiveDictationTranscriptHandler({
+						provider: this.sonioxStreaming,
+						typer: new DesktopTextTyper({
+							preferredCommand: this.config.liveDictation.insertionCommand,
+						}),
+					});
+				await this.sonioxStreaming.start(this.config.transcription.language);
+				this.streamingPcmHandler = attachStreamingPcmHandler({
+					recorder: this.recorder,
+					liveProvider: this.sonioxStreaming,
+				});
+				await this.recorder.start();
+			} catch (error) {
+				this.cancelPending = false;
+				logError("Failed to start Soniox recording", error);
+				await this.teardownStreaming(
+					"Failed to stop Soniox streaming after start failure",
+				);
+				this.setStatus("idle");
+				notify(
+					"Soniox Error",
+					"Failed to start Soniox live dictation",
+					"error",
+				);
+			}
+		} else if (this.status === "recording") {
+			this.setStatus("stopping");
+			await this.recorder.stop();
+		} else if (this.status === "starting") {
+			this.cancelPending = true;
+			logger.info("Soniox recording start cancelled by user");
+			notify("Cancelled", "Soniox recording start cancelled", "info");
+		} else {
+			logger.warn(`Soniox hotkey ignored in state: ${this.status}`);
+		}
+	}
+
+	private async processSonioxAudio(duration: number) {
+		const totalStart = Date.now();
+		try {
+			if (!this.sonioxStreaming) {
+				throw new Error("Soniox streaming session missing");
+			}
+
+			const result = await this.sonioxStreaming.stop();
+			const finalText = result.text.trim();
+			if (!finalText) {
+				logger.info({ duration }, "No speech detected in Soniox recording");
+				notify(
+					"No Speech Detected",
+					"Recording was too short or contained no audible speech.",
+					"warning",
+				);
+				this.setStatus("idle");
+				return;
+			}
+
+			await this.clipboard.append(finalText);
+			const processingTime = Date.now() - totalStart;
+
+			const stats = await incrementTranscriptionCount();
+			this.transcriptionCountToday = stats.today;
+			this.transcriptionCountTotal = stats.total;
+
+			await appendHistory({
+				timestamp: new Date().toISOString(),
+				text: finalText,
+				duration: duration / 1000,
+				engine: "soniox",
+				processingTime,
+			});
+
+			void appendStatsAggregateEntry({
+				timestamp: new Date().toISOString(),
+				engine: "soniox",
+				processingMs: processingTime,
+				mergeStrategy: "provider_bypass",
+				mergeReason: "soniox_live",
+				validationReasons: [],
+				validationRetryCount: 0,
+				validationFallbackSource: "none",
+				sonioxChunkCount: result.chunkCount,
+				sonioxStopReason: result.stopReason,
+				sonioxCloseWaitMs: result.closeWaitMs,
+			});
+
+			await this.notifyStateChange(
+				"Success",
+				"Soniox transcription copied to clipboard",
+				"success",
+			);
+			logger.info(
+				{
+					engine: "soniox",
+					textLength: finalText.length,
+					recordingDurationMs: duration,
+					processingMs: processingTime,
+					stopReason: result.stopReason,
+				},
+				"Soniox provider bypass transcription complete",
+			);
+		} catch (error: unknown) {
+			logError("Soniox processing failed", error, { duration });
+			this.errorCount++;
+			this.setStatus("error", "Soniox transcription failed. Check logs.");
+			notify("Soniox Error", "Soniox transcription failed", "error");
+		} finally {
+			this.lastTranscription = new Date();
+			if (this.liveDictationTranscriptDetach) {
+				this.liveDictationTranscriptDetach();
+				this.liveDictationTranscriptDetach = undefined;
+			}
+			if (this.streamingPcmHandler) {
+				this.recorder.off("pcm-data", this.streamingPcmHandler);
+				this.streamingPcmHandler = undefined;
+			}
+			this.sonioxStreaming = undefined;
+			this.recordingMode = "standard";
+			if (this.status !== "error") {
+				this.setStatus("idle");
+			}
 		}
 	}
 

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -12,7 +12,8 @@ import {
 import type { Config } from "../config/schema";
 import { configService } from "../config/service";
 import { ClipboardAccessError, ClipboardManager } from "../output/clipboard";
-import { DesktopTextTyper } from "../output/live-dictation";
+import { DesktopTextTyper, LiveDictationWriter } from "../output/live-dictation";
+import { formatSonioxWithLLM } from "../transcribe/soniox-streaming";
 import { notify } from "../output/notification";
 import type { DaemonStatus } from "../shared/ipc-types";
 import { appendStatsAggregateEntry } from "../stats/aggregate";
@@ -108,6 +109,7 @@ export class DaemonService {
 	private sonioxStreaming?: SonioxStreamingTranscriber;
 	private streamingPcmHandler?: (payload: PcmAudioPayload) => void;
 	private liveDictationTranscriptDetach?: () => void;
+	private liveDictationWriter?: LiveDictationWriter;
 	private liveGroqSession?: GroqLiveChunkSession;
 	private recordingMode: "standard" | "soniox" = "standard";
 	private merger: TranscriptMerger;
@@ -334,6 +336,12 @@ export class DaemonService {
 	private setupListeners() {
 		this.hotkeyListener.on("trigger", () => this.handleTrigger());
 		this.hotkeyListener.on("soniox-trigger", () => this.handleSonioxTrigger());
+		this.ipcServer.on("command", (action: string) => {
+			if (action === "soniox-toggle") {
+				logger.info("Received soniox-toggle command via IPC");
+				this.handleSonioxTrigger();
+			}
+		});
 
 		this.recorder.on("start", () => {
 			this.lastOverlayAudioLevelAt = 0;
@@ -564,13 +572,13 @@ export class DaemonService {
 						},
 					});
 					if (this.config.liveDictation.enabled) {
-						this.liveDictationTranscriptDetach =
-							attachLiveDictationTranscriptHandler({
-								provider: this.deepgramStreaming,
-								typer: new DesktopTextTyper({
-									preferredCommand: this.config.liveDictation.insertionCommand,
-								}),
-							});
+						const result = attachLiveDictationTranscriptHandler({
+							provider: this.deepgramStreaming,
+							typer: new DesktopTextTyper({
+								preferredCommand: this.config.liveDictation.insertionCommand,
+							}),
+						});
+						this.liveDictationTranscriptDetach = result.detach;
 					}
 				}
 
@@ -634,17 +642,22 @@ export class DaemonService {
 			this.cancelPending = false;
 			try {
 				this.setStatus("starting");
-				this.sonioxStreaming = new SonioxStreamingTranscriber();
+				this.sonioxStreaming = new SonioxStreamingTranscriber({
+					paragraphPauseMs:
+						this.config.liveDictation.soniox.paragraphPauseMs,
+				});
 				this.sonioxStreaming.on("error", (error) => {
 					logError("Soniox streaming error", error);
 				});
-				this.liveDictationTranscriptDetach =
+				const liveDictationResult =
 					attachLiveDictationTranscriptHandler({
 						provider: this.sonioxStreaming,
 						typer: new DesktopTextTyper({
 							preferredCommand: this.config.liveDictation.insertionCommand,
 						}),
 					});
+				this.liveDictationTranscriptDetach = liveDictationResult.detach;
+				this.liveDictationWriter = liveDictationResult.writer;
 				await this.sonioxStreaming.start(this.config.transcription.language);
 				this.streamingPcmHandler = attachStreamingPcmHandler({
 					recorder: this.recorder,
@@ -684,8 +697,8 @@ export class DaemonService {
 			}
 
 			const result = await this.sonioxStreaming.stop();
-			const finalText = result.text.trim();
-			if (!finalText) {
+			const rawText = result.text.trim();
+			if (!rawText) {
 				logger.info({ duration }, "No speech detected in Soniox recording");
 				notify(
 					"No Speech Detected",
@@ -696,7 +709,17 @@ export class DaemonService {
 				return;
 			}
 
-			await this.clipboard.append(finalText);
+			const { formattedText, llmFormattingMs } = await formatSonioxWithLLM(
+				rawText,
+				this.config.apiKeys.groq,
+				this.config.apiKeys.groqFallback,
+			);
+
+			if (this.config.liveDictation.retypeFormatted && this.liveDictationWriter) {
+				await this.liveDictationWriter.retypeFormattedText(formattedText);
+			}
+
+			await this.clipboard.append(formattedText);
 			const processingTime = Date.now() - totalStart;
 
 			const stats = await incrementTranscriptionCount();
@@ -705,7 +728,7 @@ export class DaemonService {
 
 			await appendHistory({
 				timestamp: new Date().toISOString(),
-				text: finalText,
+				text: formattedText,
 				duration: duration / 1000,
 				engine: "soniox",
 				processingTime,
@@ -715,6 +738,7 @@ export class DaemonService {
 				timestamp: new Date().toISOString(),
 				engine: "soniox",
 				processingMs: processingTime,
+				llmFormattingMs,
 				mergeStrategy: "provider_bypass",
 				mergeReason: "soniox_live",
 				validationReasons: [],
@@ -733,12 +757,28 @@ export class DaemonService {
 			logger.info(
 				{
 					engine: "soniox",
-					textLength: finalText.length,
+					textLength: formattedText.length,
 					recordingDurationMs: duration,
 					processingMs: processingTime,
 					stopReason: result.stopReason,
 				},
 				"Soniox provider bypass transcription complete",
+			);
+
+			logger.info(
+				{
+					type: "perf",
+					engine: "soniox",
+					textLength: formattedText.length,
+					recordingDurationMs: duration,
+					processingMs: processingTime,
+					llmFormattingMs,
+					tokenCount: result.chunkCount,
+					paragraphBreakCount: result.paragraphBreakCount,
+					stopReason: result.stopReason,
+					closeWaitMs: result.closeWaitMs,
+				},
+				"Soniox transcription performance",
 			);
 		} catch (error: unknown) {
 			logError("Soniox processing failed", error, { duration });

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -4,32 +4,29 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { convertAudio } from "../audio/converter";
 import {
-	assertAudioBackendAvailable,
 	type AudioLevelPayload,
 	AudioRecorder,
+	assertAudioBackendAvailable,
 	type PcmAudioPayload,
 } from "../audio/recorder";
 import type { Config } from "../config/schema";
 import { configService } from "../config/service";
 import { ClipboardAccessError, ClipboardManager } from "../output/clipboard";
+import { DesktopTextTyper } from "../output/live-dictation";
 import { notify } from "../output/notification";
 import type { DaemonStatus } from "../shared/ipc-types";
 import { appendStatsAggregateEntry } from "../stats/aggregate";
 import { DeepgramTranscriber } from "../transcribe/deepgram";
-import {
+import type {
 	DeepgramStreamingTranscriber,
-	type StreamingFailureReason,
-	type StreamingStopReason,
+	StreamingStopReason,
 } from "../transcribe/deepgram-streaming";
 import { GroqClient } from "../transcribe/groq";
 import {
 	createGroqChunkingMetrics,
 	GroqChunkingError,
-	type GroqChunkingMetrics,
 } from "../transcribe/groq-chunking";
-import {
-	GroqLiveChunkSession,
-} from "../transcribe/groq-live-chunking";
+import type { GroqLiveChunkSession } from "../transcribe/groq-live-chunking";
 import { assessGroqLiveQualityFallback } from "../transcribe/groq-live-quality";
 import { buildContextLexicon } from "../transcribe/lexicon";
 import { assessLongRecordingQuality } from "../transcribe/long-recording";
@@ -41,14 +38,15 @@ import { errorIncludes, getErrorCode } from "../utils/errors";
 import { appendHistory } from "../utils/history";
 import { logError, logger } from "../utils/logger";
 import { incrementTranscriptionCount, loadStats } from "../utils/stats";
-import { checkHotkeyConflict } from "./conflict";
 import { shouldCompressAudio } from "./audio-strategy";
+import { checkHotkeyConflict } from "./conflict";
 import { saveDebugAudioCapture } from "./debug-audio";
 import { runGroqTranscriptionWithLiveSession } from "./groq-transcription";
 import { HotkeyListener } from "./hotkey";
 import { getIPCServer, type IPCServer } from "./ipc";
 import { OverlayProcessManager } from "./overlay-process";
 import {
+	attachLiveDictationTranscriptHandler,
 	attachStreamingPcmHandler,
 	createLiveGroqSession,
 	startDeepgramStreaming,
@@ -107,6 +105,7 @@ export class DaemonService {
 	private deepgram: DeepgramTranscriber;
 	private deepgramStreaming?: DeepgramStreamingTranscriber;
 	private streamingPcmHandler?: (payload: PcmAudioPayload) => void;
+	private liveDictationTranscriptDetach?: () => void;
 	private liveGroqSession?: GroqLiveChunkSession;
 	private merger: TranscriptMerger;
 	private clipboard: ClipboardManager;
@@ -471,6 +470,10 @@ export class DaemonService {
 	 * half-started recording never leaks an open socket or in-flight chunk.
 	 */
 	private async teardownStreaming(reason: string): Promise<void> {
+		if (this.liveDictationTranscriptDetach) {
+			this.liveDictationTranscriptDetach();
+			this.liveDictationTranscriptDetach = undefined;
+		}
 		if (this.streamingPcmHandler) {
 			this.recorder.off("pcm-data", this.streamingPcmHandler);
 			this.streamingPcmHandler = undefined;
@@ -489,16 +492,25 @@ export class DaemonService {
 			try {
 				this.setStatus("starting");
 
-					if (this.streamingPcmHandler) {
-						this.recorder.off("pcm-data", this.streamingPcmHandler);
-						logger.debug("Removed old streaming PCM handler");
-					}
-					this.streamingPcmHandler = undefined;
+				if (this.streamingPcmHandler) {
+					this.recorder.off("pcm-data", this.streamingPcmHandler);
+					logger.debug("Removed old streaming PCM handler");
+				}
+				this.streamingPcmHandler = undefined;
 
-					this.liveGroqSession = createLiveGroqSession({
-						config: this.config,
-						boostWords: this.providerBoostWords,
-						transcribe: (
+				this.liveGroqSession = createLiveGroqSession({
+					config: this.config,
+					boostWords: this.providerBoostWords,
+					transcribe: (
+						buffer,
+						language,
+						boostWords,
+						format,
+						recordingMs,
+						contextHint,
+						signal,
+					) =>
+						this.groq.transcribe(
 							buffer,
 							language,
 							boostWords,
@@ -506,69 +518,69 @@ export class DaemonService {
 							recordingMs,
 							contextHint,
 							signal,
-						) =>
-							this.groq.transcribe(
-								buffer,
-								language,
-								boostWords,
-								format,
-								recordingMs,
-								contextHint,
-								signal,
-							),
+						),
+				});
+
+				if (this.config.transcription.streaming) {
+					this.deepgramStreaming = startDeepgramStreaming({
+						config: this.config,
+						boostWords: this.providerBoostWords,
+						onStreamingInterrupted: () => {
+							this.notifyStateChange(
+								"Streaming Interrupted",
+								"Using batch transcription",
+								"warning",
+							);
+						},
 					});
-
-					if (this.config.transcription.streaming) {
-						this.deepgramStreaming = startDeepgramStreaming({
-							config: this.config,
-							boostWords: this.providerBoostWords,
-							onStreamingInterrupted: () => {
-								this.notifyStateChange(
-									"Streaming Interrupted",
-									"Using batch transcription",
-									"warning",
-								);
-							},
-						});
+					if (this.config.liveDictation.enabled) {
+						this.liveDictationTranscriptDetach =
+							attachLiveDictationTranscriptHandler({
+								provider: this.deepgramStreaming,
+								typer: new DesktopTextTyper({
+									preferredCommand: this.config.liveDictation.insertionCommand,
+								}),
+							});
 					}
+				}
 
-					if (this.cancelPending) {
-						logger.info("Recording cancelled during setup, cleaning up");
-						this.cancelPending = false;
-						await this.teardownStreaming(
-							"Failed to stop streaming after cancellation",
-						);
-						this.setStatus("idle");
-						return;
-					}
+				if (this.cancelPending) {
+					logger.info("Recording cancelled during setup, cleaning up");
+					this.cancelPending = false;
+					await this.teardownStreaming(
+						"Failed to stop streaming after cancellation",
+					);
+					this.setStatus("idle");
+					return;
+				}
 
-					if (this.deepgramStreaming || this.liveGroqSession) {
-						this.streamingPcmHandler = attachStreamingPcmHandler({
-							recorder: this.recorder,
-							deepgramStreaming: this.deepgramStreaming,
-							liveGroqSession: this.liveGroqSession,
-						});
-					}
+				if (this.deepgramStreaming || this.liveGroqSession) {
+					this.streamingPcmHandler = attachStreamingPcmHandler({
+						recorder: this.recorder,
+						deepgramStreaming: this.deepgramStreaming,
+						liveGroqSession: this.liveGroqSession,
+					});
+				}
 
-					if (this.cancelPending) {
-						logger.info("Recording cancelled before recorder start, cleaning up");
-						this.cancelPending = false;
-						await this.teardownStreaming(
-							"Failed to stop streaming after cancellation",
-						);
-						this.setStatus("idle");
-						return;
-					}
+				if (this.cancelPending) {
+					logger.info("Recording cancelled before recorder start, cleaning up");
+					this.cancelPending = false;
+					await this.teardownStreaming(
+						"Failed to stop streaming after cancellation",
+					);
+					this.setStatus("idle");
+					return;
+				}
 
 				await this.recorder.start();
 			} catch (error) {
-					this.cancelPending = false;
-					logError("Failed to start recording", error);
-					await this.teardownStreaming(
-						"Failed to stop streaming after start failure",
-					);
-					this.setStatus("idle");
-				}
+				this.cancelPending = false;
+				logError("Failed to start recording", error);
+				await this.teardownStreaming(
+					"Failed to stop streaming after start failure",
+				);
+				this.setStatus("idle");
+			}
 		} else if (this.status === "recording") {
 			this.setStatus("stopping");
 			await this.recorder.stop();
@@ -589,9 +601,11 @@ export class DaemonService {
 			audioBuffer.length,
 			duration,
 		);
-		void saveDebugAudioCapture(this.config, audioBuffer, duration).catch((error) => {
-			logError("Failed to save debug transcription audio", error);
-		});
+		void saveDebugAudioCapture(this.config, audioBuffer, duration).catch(
+			(error) => {
+				logError("Failed to save debug transcription audio", error);
+			},
+		);
 
 		try {
 			const language = this.config.transcription.language;
@@ -907,7 +921,8 @@ export class DaemonService {
 				}
 
 				if (groqErr) handleProviderTranscriptionError(groqErr, "Groq");
-				if (deepgramErr) handleProviderTranscriptionError(deepgramErr, "Deepgram");
+				if (deepgramErr)
+					handleProviderTranscriptionError(deepgramErr, "Deepgram");
 
 				const template = ErrorTemplates.API.BOTH_SERVICES_FAILED;
 				notify("Transcription Failed", formatUserError(template), "error");

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -658,7 +658,10 @@ export class DaemonService {
 					});
 				this.liveDictationTranscriptDetach = liveDictationResult.detach;
 				this.liveDictationWriter = liveDictationResult.writer;
-				await this.sonioxStreaming.start(this.config.transcription.language);
+				await this.sonioxStreaming.start(
+					this.config.transcription.language,
+					this.providerBoostWords,
+				);
 				this.streamingPcmHandler = attachStreamingPcmHandler({
 					recorder: this.recorder,
 					liveProvider: this.sonioxStreaming,

--- a/src/output/live-dictation.ts
+++ b/src/output/live-dictation.ts
@@ -44,7 +44,7 @@ export class DesktopTextTyper implements TextTyper {
 
 	private resolveSelectCommand(): { command: string; args: string[] } {
 		if (this.env.WAYLAND_DISPLAY && this.isCommandAvailable("wtype")) {
-			return { command: "wtype", args: ["--", "\x1b[H\x1b[1;2C"] };
+			return { command: "wtype", args: ["--", "\x1b[H\x1b[1;2F"] };
 		}
 
 		if (this.isCommandAvailable("xdotool")) {

--- a/src/output/live-dictation.ts
+++ b/src/output/live-dictation.ts
@@ -1,0 +1,93 @@
+import { spawn, spawnSync } from "node:child_process";
+
+export interface TextTyper {
+	typeText(text: string): Promise<void>;
+}
+
+type RunCommand = (command: string, args: string[]) => Promise<void>;
+type IsCommandAvailable = (command: string) => boolean;
+
+interface DesktopTextTyperOptions {
+	env?: NodeJS.ProcessEnv;
+	isCommandAvailable?: IsCommandAvailable;
+	runCommand?: RunCommand;
+}
+
+export class DesktopTextTyper implements TextTyper {
+	private readonly env: NodeJS.ProcessEnv;
+	private readonly isCommandAvailable: IsCommandAvailable;
+	private readonly runCommand: RunCommand;
+
+	public constructor(options: DesktopTextTyperOptions = {}) {
+		this.env = options.env ?? process.env;
+		this.isCommandAvailable =
+			options.isCommandAvailable ?? defaultIsCommandAvailable;
+		this.runCommand = options.runCommand ?? defaultRunCommand;
+	}
+
+	public async typeText(text: string): Promise<void> {
+		const command = this.resolveCommand();
+		await this.runCommand(command.command, [...command.args, text]);
+	}
+
+	private resolveCommand(): { command: string; args: string[] } {
+		if (this.env.WAYLAND_DISPLAY && this.isCommandAvailable("wtype")) {
+			return { command: "wtype", args: [] };
+		}
+
+		if (this.isCommandAvailable("xdotool")) {
+			return { command: "xdotool", args: ["type", "--clearmodifiers", "--"] };
+		}
+
+		throw new Error(
+			"Live Dictation requires wtype on Wayland or xdotool on X11",
+		);
+	}
+}
+
+export class LiveDictationWriter {
+	private committedText = "";
+
+	public constructor(private readonly typer: TextTyper) {}
+
+	public async acceptCommittedTranscript(
+		nextTranscript: string,
+	): Promise<void> {
+		if (!nextTranscript.startsWith(this.committedText)) {
+			this.committedText = nextTranscript;
+			await this.typer.typeText(nextTranscript);
+			return;
+		}
+
+		const delta = nextTranscript.slice(this.committedText.length);
+		this.committedText = nextTranscript;
+		if (delta.length === 0) {
+			return;
+		}
+
+		await this.typer.typeText(delta);
+	}
+
+	public reset(): void {
+		this.committedText = "";
+	}
+}
+
+function defaultIsCommandAvailable(command: string): boolean {
+	const result = spawnSync("which", [command], { stdio: "ignore" });
+	return result.status === 0;
+}
+
+function defaultRunCommand(command: string, args: string[]): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, { stdio: "ignore" });
+		child.on("error", reject);
+		child.on("close", (code) => {
+			if (code === 0) {
+				resolve();
+				return;
+			}
+			reject(new Error(`${command} exited with code ${code}`));
+		});
+	});
+}

--- a/src/output/live-dictation.ts
+++ b/src/output/live-dictation.ts
@@ -44,7 +44,10 @@ export class DesktopTextTyper implements TextTyper {
 
 	private resolveSelectCommand(): { command: string; args: string[] } {
 		if (this.env.WAYLAND_DISPLAY && this.isCommandAvailable("wtype")) {
-			return { command: "wtype", args: ["--", "\x1b[H\x1b[1;2F"] };
+			return {
+				command: "wtype",
+				args: ["-k", "Home", "-M", "shift", "-k", "End", "-m", "shift"],
+			};
 		}
 
 		if (this.isCommandAvailable("xdotool")) {

--- a/src/output/live-dictation.ts
+++ b/src/output/live-dictation.ts
@@ -6,19 +6,23 @@ export interface TextTyper {
 
 type RunCommand = (command: string, args: string[]) => Promise<void>;
 type IsCommandAvailable = (command: string) => boolean;
+export type TextInsertionCommand = "auto" | "wtype" | "xdotool";
 
 interface DesktopTextTyperOptions {
+	preferredCommand?: TextInsertionCommand;
 	env?: NodeJS.ProcessEnv;
 	isCommandAvailable?: IsCommandAvailable;
 	runCommand?: RunCommand;
 }
 
 export class DesktopTextTyper implements TextTyper {
+	private readonly preferredCommand: TextInsertionCommand;
 	private readonly env: NodeJS.ProcessEnv;
 	private readonly isCommandAvailable: IsCommandAvailable;
 	private readonly runCommand: RunCommand;
 
 	public constructor(options: DesktopTextTyperOptions = {}) {
+		this.preferredCommand = options.preferredCommand ?? "auto";
 		this.env = options.env ?? process.env;
 		this.isCommandAvailable =
 			options.isCommandAvailable ?? defaultIsCommandAvailable;
@@ -31,6 +35,16 @@ export class DesktopTextTyper implements TextTyper {
 	}
 
 	private resolveCommand(): { command: string; args: string[] } {
+		if (this.preferredCommand === "wtype") {
+			this.assertCommandAvailable("wtype");
+			return { command: "wtype", args: [] };
+		}
+
+		if (this.preferredCommand === "xdotool") {
+			this.assertCommandAvailable("xdotool");
+			return { command: "xdotool", args: ["type", "--clearmodifiers", "--"] };
+		}
+
 		if (this.env.WAYLAND_DISPLAY && this.isCommandAvailable("wtype")) {
 			return { command: "wtype", args: [] };
 		}
@@ -42,6 +56,14 @@ export class DesktopTextTyper implements TextTyper {
 		throw new Error(
 			"Live Dictation requires wtype on Wayland or xdotool on X11",
 		);
+	}
+
+	private assertCommandAvailable(command: "wtype" | "xdotool"): void {
+		if (this.isCommandAvailable(command)) {
+			return;
+		}
+
+		throw new Error(`Live Dictation command not found: ${command}`);
 	}
 }
 

--- a/src/output/live-dictation.ts
+++ b/src/output/live-dictation.ts
@@ -34,6 +34,31 @@ export class DesktopTextTyper implements TextTyper {
 		await this.runCommand(command.command, [...command.args, text]);
 	}
 
+	public async selectLineAndType(text: string): Promise<void> {
+		const selectCommand = this.resolveSelectCommand();
+		await this.runCommand(selectCommand.command, selectCommand.args);
+
+		const typeCommand = this.resolveCommand();
+		await this.runCommand(typeCommand.command, [...typeCommand.args, text]);
+	}
+
+	private resolveSelectCommand(): { command: string; args: string[] } {
+		if (this.env.WAYLAND_DISPLAY && this.isCommandAvailable("wtype")) {
+			return { command: "wtype", args: ["--", "\x1b[H\x1b[1;2C"] };
+		}
+
+		if (this.isCommandAvailable("xdotool")) {
+			return {
+				command: "xdotool",
+				args: ["key", "--clearmodifiers", "Home", "shift+End"],
+			};
+		}
+
+		throw new Error(
+			"Live Dictation retype requires wtype on Wayland or xdotool on X11",
+		);
+	}
+
 	private resolveCommand(): { command: string; args: string[] } {
 		if (this.preferredCommand === "wtype") {
 			this.assertCommandAvailable("wtype");
@@ -88,6 +113,21 @@ export class LiveDictationWriter {
 		}
 
 		await this.typer.typeText(delta);
+	}
+
+	public async retypeFormattedText(formattedText: string): Promise<void> {
+		const typer = this.typer as DesktopTextTyper;
+		if (typeof typer.selectLineAndType !== "function") {
+			await this.typer.typeText(formattedText);
+			return;
+		}
+
+		await typer.selectLineAndType(formattedText);
+		this.committedText = formattedText;
+	}
+
+	public getCommittedText(): string {
+		return this.committedText;
 	}
 
 	public reset(): void {

--- a/src/shared/ipc-types.ts
+++ b/src/shared/ipc-types.ts
@@ -22,6 +22,11 @@ export interface AudioLevelMessage {
 	timestamp: number;
 }
 
+export interface ActionMessage {
+	type: "action";
+	action: "soniox-toggle";
+}
+
 export type IPCMessage =
 	| {
 			type: "hello" | "state";
@@ -31,4 +36,5 @@ export type IPCMessage =
 			error?: string;
 			timestamp?: number;
 	  }
-	| AudioLevelMessage;
+	| AudioLevelMessage
+	| ActionMessage;

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -30,6 +30,7 @@ export interface StreamingResult {
 	endpointingMs: number;
 	receivedFinalChunk: boolean;
 	hadSpeechFinal: boolean;
+	paragraphBreakCount?: number;
 }
 
 export interface StreamingFailureReason {

--- a/src/transcribe/deepgram-streaming.ts
+++ b/src/transcribe/deepgram-streaming.ts
@@ -9,6 +9,10 @@ import {
 import { loadConfig } from "../config/loader";
 import { logError, logger } from "../utils/logger";
 import { sanitizeDeepgramKeyterms } from "./deepgram-boost";
+import type {
+	LiveStreamingProvider,
+	LiveTranscriptEvent,
+} from "./live-provider";
 
 export type StreamingStopReason =
 	| "finalize_transcript"
@@ -36,7 +40,10 @@ export interface StreamingFailureReason {
 	chunksSent: number;
 }
 
-export class DeepgramStreamingTranscriber extends EventEmitter {
+export class DeepgramStreamingTranscriber
+	extends EventEmitter
+	implements LiveStreamingProvider
+{
 	private client: DeepgramClient;
 	private connection: LiveClient | null = null;
 	private transcriptChunks: string[] = [];
@@ -120,20 +127,24 @@ export class DeepgramStreamingTranscriber extends EventEmitter {
 							{ transcript: transcript.trim(), isFinal: true },
 							"Deepgram chunk finalized (speech_final)",
 						);
-						this.emit("transcript", transcript.trim(), {
+						const event: LiveTranscriptEvent = {
+							text: transcript.trim(),
 							isFinal: data.is_final,
 							speechFinal: data.speech_final,
-						});
+						};
+						this.emit("transcript", transcript.trim(), event);
 					} else if (data.is_final) {
 						this.transcriptChunks.push(transcript.trim());
 						logger.debug(
 							{ transcript: transcript.trim(), isFinal: data.is_final },
 							"Deepgram chunk finalized (is_final)",
 						);
-						this.emit("transcript", transcript.trim(), {
+						const event: LiveTranscriptEvent = {
+							text: transcript.trim(),
 							isFinal: data.is_final,
 							speechFinal: data.speech_final,
-						});
+						};
+						this.emit("transcript", transcript.trim(), event);
 					}
 				}
 			});

--- a/src/transcribe/live-provider.ts
+++ b/src/transcribe/live-provider.ts
@@ -1,0 +1,17 @@
+import type { StreamingResult } from "./deepgram-streaming";
+
+export interface LiveTranscriptEvent {
+	text: string;
+	isFinal: boolean;
+	speechFinal: boolean;
+}
+
+export interface LiveStreamingProvider {
+	start(language: string, boostWords?: string[]): Promise<void>;
+	send(audioChunk: Buffer): void;
+	stop(): Promise<StreamingResult>;
+}
+
+export function isCommittedLiveTranscript(event: LiveTranscriptEvent): boolean {
+	return event.isFinal || event.speechFinal;
+}

--- a/src/transcribe/soniox-streaming.ts
+++ b/src/transcribe/soniox-streaming.ts
@@ -80,7 +80,7 @@ export class SonioxStreamingTranscriber
 			((url) => new WebSocket(url) as unknown as SonioxWebSocketLike);
 	}
 
-	public async start(language: string = "en"): Promise<void> {
+	public async start(language: string = "en", boostWords: string[] = []): Promise<void> {
 		this.transcriptChunks = [];
 		this.audioBuffer = [];
 		this.isConnected = false;
@@ -97,17 +97,22 @@ export class SonioxStreamingTranscriber
 
 			this.isConnected = true;
 			this.isConnecting = false;
-			this.connection.send(
-				JSON.stringify({
-					api_key: this.apiKey,
-					model: SONIOX_MODEL,
-					audio_format: "pcm_s16le",
-					sample_rate: SONIOX_SAMPLE_RATE,
-					num_channels: 1,
-					language_hints: [language],
-					enable_endpoint_detection: true,
-				}),
-			);
+
+			const config: Record<string, unknown> = {
+				api_key: this.apiKey,
+				model: SONIOX_MODEL,
+				audio_format: "pcm_s16le",
+				sample_rate: SONIOX_SAMPLE_RATE,
+				num_channels: 1,
+				language_hints: [language],
+				enable_endpoint_detection: true,
+			};
+
+			if (boostWords.length > 0) {
+				config.context = { terms: boostWords };
+			}
+
+			this.connection.send(JSON.stringify(config));
 			logger.info({ language }, "Soniox streaming connection opened");
 			this.emit("open");
 			this.flushBuffer();

--- a/src/transcribe/soniox-streaming.ts
+++ b/src/transcribe/soniox-streaming.ts
@@ -43,6 +43,7 @@ interface SonioxStreamingTranscriberOptions {
 	apiKey?: string;
 	endpoint?: string;
 	createWebSocket?: CreateSonioxWebSocket;
+	paragraphPauseMs?: number;
 }
 
 export class SonioxStreamingTranscriber
@@ -52,12 +53,17 @@ export class SonioxStreamingTranscriber
 	private readonly apiKey: string;
 	private readonly endpoint: string;
 	private readonly createWebSocket: CreateSonioxWebSocket;
+	private readonly paragraphPauseMs: number;
 	private connection: SonioxWebSocketLike | null = null;
 	private transcriptChunks: string[] = [];
 	private audioBuffer: Buffer[] = [];
 	private isConnected = false;
 	private isConnecting = false;
 	private chunksSent = 0;
+	private lastEmittedFullText = "";
+	private lastMessageTimestamp = 0;
+	private hasReceivedMessage = false;
+	private paragraphBreakCount = 0;
 
 	public constructor(options: SonioxStreamingTranscriberOptions = {}) {
 		super();
@@ -68,6 +74,7 @@ export class SonioxStreamingTranscriber
 
 		this.apiKey = apiKey;
 		this.endpoint = options.endpoint ?? SONIOX_WEBSOCKET_ENDPOINT;
+		this.paragraphPauseMs = options.paragraphPauseMs ?? 3000;
 		this.createWebSocket =
 			options.createWebSocket ??
 			((url) => new WebSocket(url) as unknown as SonioxWebSocketLike);
@@ -79,6 +86,10 @@ export class SonioxStreamingTranscriber
 		this.isConnected = false;
 		this.isConnecting = true;
 		this.chunksSent = 0;
+		this.lastEmittedFullText = "";
+		this.lastMessageTimestamp = 0;
+		this.hasReceivedMessage = false;
+		this.paragraphBreakCount = 0;
 
 		this.connection = this.createWebSocket(this.endpoint);
 		this.connection.onopen = () => {
@@ -168,6 +179,7 @@ export class SonioxStreamingTranscriber
 		return {
 			text: finalText,
 			chunkCount: this.transcriptChunks.length,
+			paragraphBreakCount: this.paragraphBreakCount,
 			stopReason,
 			finalizeWaitMs: 0,
 			closeWaitMs,
@@ -189,16 +201,45 @@ export class SonioxStreamingTranscriber
 				return;
 			}
 
-			const finalText = renderFinalTokenText(response.tokens ?? []);
-			if (!finalText) return;
+			const tokens = response.tokens ?? [];
+			for (const token of tokens) {
+				logger.debug(
+					{ text: token.text, isFinal: token.is_final },
+					"Soniox token received",
+				);
+			}
 
-			this.transcriptChunks.push(finalText);
+			const fullText = renderFinalTokenText(tokens);
+			const delta = fullText.slice(this.lastEmittedFullText.length);
+			this.lastEmittedFullText = fullText;
+
+			if (!delta) return;
+
+			const now = Date.now();
+			const gapMs = this.lastMessageTimestamp > 0
+				? now - this.lastMessageTimestamp
+				: 0;
+			this.lastMessageTimestamp = now;
+
+			let prefix = "";
+			if (this.hasReceivedMessage && gapMs >= this.paragraphPauseMs) {
+				prefix = "  ";
+				this.paragraphBreakCount++;
+				logger.debug(
+					{ gapMs, paragraphPauseMs: this.paragraphPauseMs },
+					"Soniox paragraph break inserted",
+				);
+			}
+			this.hasReceivedMessage = true;
+
+			logger.debug({ delta, fullText }, "Soniox transcript delta emitted");
+			this.transcriptChunks.push(prefix + delta);
 			const event: LiveTranscriptEvent = {
-				text: finalText,
+				text: prefix + fullText,
 				isFinal: true,
 				speechFinal: true,
 			};
-			this.emit("transcript", finalText, event);
+			this.emit("transcript", prefix + fullText, event);
 		} catch (error) {
 			logError("Failed to parse Soniox streaming response", error);
 		}
@@ -228,9 +269,123 @@ export class SonioxStreamingTranscriber
 	}
 }
 
+const SONIOX_STRIP_PATTERN = /<\|?end\|?>|<\|?start\|?>|<\|\d+\.\d+\|>/g;
+
 function renderFinalTokenText(tokens: SonioxToken[]): string {
-	return tokens
+	const text = tokens
 		.filter((token) => token.is_final && token.text)
-		.map((token) => token.text)
-		.join("");
+		.map((token) => (token.text ?? "").replace(SONIOX_STRIP_PATTERN, ""))
+		.join(" ");
+
+	return text.replace(/  +/g, " ").trim();
+}
+
+const LLM_FORMAT_SYSTEM_PROMPT = `Task: add paragraph breaks to raw dictation text.
+
+Output contract:
+- Return the text with paragraph breaks inserted at natural sentence boundaries.
+- Do not add any content, metadata, or explanations.
+- Do not modify the text itself, only insert paragraph breaks (\\n\\n).
+- Preserve all original wording exactly.
+- Insert paragraph breaks between topics or after a pause in thought.
+
+Input: Raw dictation text with double-space paragraph markers.`;
+
+export async function formatSonioxWithLLM(
+	text: string,
+	apiKey: string,
+	fallbackApiKey?: string,
+): Promise<{ formattedText: string; llmFormattingMs: number }> {
+	const startTime = Date.now();
+	try {
+		const GroqModule = await import("groq-sdk");
+		const Groq = GroqModule.default;
+		const client = new Groq({ apiKey });
+
+		const completion = await client.chat.completions.create({
+			model: "llama-3.3-70b-versatile",
+			messages: [
+				{ role: "system", content: LLM_FORMAT_SYSTEM_PROMPT },
+				{ role: "user", content: text },
+			],
+			temperature: 0,
+			max_tokens: Math.ceil(text.length / 3),
+			seed: 42,
+		});
+
+		const formattedText =
+			completion.choices[0]?.message?.content?.trim() ?? text;
+		const llmFormattingMs = Date.now() - startTime;
+
+		logger.debug(
+			{ originalLength: text.length, formattedLength: formattedText.length, llmFormattingMs },
+			"Soniox LLM formatting complete",
+		);
+
+		return { formattedText, llmFormattingMs };
+	} catch (error) {
+		const llmFormattingMs = Date.now() - startTime;
+		logError("Soniox LLM formatting failed; using raw text", error);
+		return { formattedText: text, llmFormattingMs };
+	}
+}
+
+const LLM_FORMATTING_SYSTEM_PROMPT = `Task: add paragraph breaks to the following transcript text.
+
+Output contract:
+- Return the transcript text with paragraph breaks added.
+- Do not modify the wording, punctuation, or content in any way.
+- Do not remove filler words, fix grammar, or rewrite anything.
+- Do not emit metadata, labels, instructions, or explanations.
+
+Paragraph break rules:
+- Insert a blank line (double newline) between distinct topic changes or when there's a clear pause in thought.
+- Do not add paragraph breaks within sentences.
+- Do not add paragraph breaks to very short texts (under 100 characters).
+- If the text is already well-structured with paragraph breaks, return it unchanged.
+
+Invalid output:
+- Any changes to wording, punctuation, or content.
+- Added explanations or metadata.`;
+
+export async function formatSonioxWithLlm(text: string): Promise<string> {
+	if (text.length < 100) return text;
+
+	const config = loadConfig();
+	const apiKey = config.apiKeys.groq;
+	if (!apiKey) {
+		logger.warn("No Groq API key available for LLM formatting; returning raw text");
+		return text;
+	}
+
+	try {
+		const GroqSdk = (await import("groq-sdk")).default;
+		const client = new GroqSdk({ apiKey });
+
+		const response = await client.chat.completions.create({
+			model: "llama-3.3-70b-versatile",
+			messages: [
+				{ role: "system", content: LLM_FORMATTING_SYSTEM_PROMPT },
+				{ role: "user", content: text },
+			],
+			temperature: 0,
+			max_tokens: Math.min(Math.ceil(text.length * 1.5), 4096),
+			seed: 42,
+		});
+
+		const formatted = response.choices[0]?.message?.content?.trim();
+		if (formatted && formatted.length > 0) {
+			logger.debug(
+				{ rawLength: text.length, formattedLength: formatted.length },
+				"LLM formatting applied to Soniox transcript",
+			);
+			return formatted;
+		}
+
+		logger.warn("LLM returned empty formatting result; using raw text");
+		return text;
+	} catch (error) {
+		logError("LLM formatting failed; using raw text", error);
+		return text;
+	}
 }

--- a/src/transcribe/soniox-streaming.ts
+++ b/src/transcribe/soniox-streaming.ts
@@ -1,0 +1,236 @@
+import { EventEmitter } from "node:events";
+import { loadConfig } from "../config/loader";
+import { logError, logger } from "../utils/logger";
+import type {
+	StreamingResult,
+	StreamingStopReason,
+} from "./deepgram-streaming";
+import type {
+	LiveStreamingProvider,
+	LiveTranscriptEvent,
+} from "./live-provider";
+
+const SONIOX_WEBSOCKET_ENDPOINT =
+	"wss://stt-rt.soniox.com/transcribe-websocket";
+const SONIOX_MODEL = "stt-rt-v5";
+const SONIOX_SAMPLE_RATE = 16000;
+const SONIOX_CLOSE_TIMEOUT_MS = 2000;
+
+interface SonioxToken {
+	text?: string;
+	is_final?: boolean;
+}
+
+interface SonioxResponse {
+	tokens?: SonioxToken[];
+	error_code?: string;
+	error_message?: string;
+}
+
+interface SonioxWebSocketLike {
+	readonly readyState: number;
+	onopen: (() => void) | null;
+	onmessage: ((event: { data: unknown }) => void) | null;
+	onerror: ((event: unknown) => void) | null;
+	onclose: (() => void) | null;
+	send(data: string | Buffer): void;
+	close(): void;
+}
+
+type CreateSonioxWebSocket = (url: string) => SonioxWebSocketLike;
+
+interface SonioxStreamingTranscriberOptions {
+	apiKey?: string;
+	endpoint?: string;
+	createWebSocket?: CreateSonioxWebSocket;
+}
+
+export class SonioxStreamingTranscriber
+	extends EventEmitter
+	implements LiveStreamingProvider
+{
+	private readonly apiKey: string;
+	private readonly endpoint: string;
+	private readonly createWebSocket: CreateSonioxWebSocket;
+	private connection: SonioxWebSocketLike | null = null;
+	private transcriptChunks: string[] = [];
+	private audioBuffer: Buffer[] = [];
+	private isConnected = false;
+	private isConnecting = false;
+	private chunksSent = 0;
+
+	public constructor(options: SonioxStreamingTranscriberOptions = {}) {
+		super();
+		const apiKey = options.apiKey ?? loadConfig().apiKeys.soniox;
+		if (!apiKey) {
+			throw new Error("Soniox API key is required for live dictation");
+		}
+
+		this.apiKey = apiKey;
+		this.endpoint = options.endpoint ?? SONIOX_WEBSOCKET_ENDPOINT;
+		this.createWebSocket =
+			options.createWebSocket ??
+			((url) => new WebSocket(url) as unknown as SonioxWebSocketLike);
+	}
+
+	public async start(language: string = "en"): Promise<void> {
+		this.transcriptChunks = [];
+		this.audioBuffer = [];
+		this.isConnected = false;
+		this.isConnecting = true;
+		this.chunksSent = 0;
+
+		this.connection = this.createWebSocket(this.endpoint);
+		this.connection.onopen = () => {
+			if (!this.connection) return;
+
+			this.isConnected = true;
+			this.isConnecting = false;
+			this.connection.send(
+				JSON.stringify({
+					api_key: this.apiKey,
+					model: SONIOX_MODEL,
+					audio_format: "pcm_s16le",
+					sample_rate: SONIOX_SAMPLE_RATE,
+					num_channels: 1,
+					language_hints: [language],
+					enable_endpoint_detection: true,
+				}),
+			);
+			logger.info({ language }, "Soniox streaming connection opened");
+			this.emit("open");
+			this.flushBuffer();
+		};
+
+		this.connection.onmessage = (event) => {
+			this.handleMessage(event.data);
+		};
+
+		this.connection.onerror = (event) => {
+			this.isConnected = false;
+			this.isConnecting = false;
+			logger.error({ event }, "Soniox streaming error");
+			this.emit("error", event);
+		};
+
+		this.connection.onclose = () => {
+			this.isConnected = false;
+			this.isConnecting = false;
+			logger.info(
+				{
+					chunksReceived: this.transcriptChunks.length,
+					chunksSent: this.chunksSent,
+				},
+				"Soniox streaming connection closed",
+			);
+			this.emit("close");
+		};
+	}
+
+	public send(audioChunk: Buffer): void {
+		if (this.connection && this.isConnected) {
+			this.connection.send(audioChunk);
+			this.chunksSent++;
+			return;
+		}
+
+		if (this.isConnecting) {
+			this.audioBuffer.push(audioChunk);
+		}
+	}
+
+	public async stop(): Promise<StreamingResult> {
+		let stopReason: StreamingStopReason = "not_connected";
+		let closeWaitMs = 0;
+
+		if (this.connection) {
+			try {
+				this.connection.send("");
+				stopReason = "finalize_transcript";
+				const closeStart = Date.now();
+				const closeClean = await this.waitForClose();
+				closeWaitMs = Date.now() - closeStart;
+				if (!closeClean) {
+					stopReason = "finalize_transcript+close_timeout";
+					this.connection.close();
+				}
+			} catch (error) {
+				logError("Error finishing Soniox streaming", error);
+			} finally {
+				this.connection = null;
+				this.isConnected = false;
+				this.isConnecting = false;
+				this.audioBuffer = [];
+			}
+		}
+
+		const finalText = this.transcriptChunks.join("").trim();
+		return {
+			text: finalText,
+			chunkCount: this.transcriptChunks.length,
+			stopReason,
+			finalizeWaitMs: 0,
+			closeWaitMs,
+			endpointingMs: 0,
+			receivedFinalChunk: this.transcriptChunks.length > 0,
+			hadSpeechFinal: this.transcriptChunks.length > 0,
+		};
+	}
+
+	private handleMessage(data: unknown): void {
+		try {
+			const response = JSON.parse(String(data)) as SonioxResponse;
+			if (response.error_code || response.error_message) {
+				const message =
+					response.error_message ??
+					`Soniox streaming error: ${response.error_code ?? "unknown"}`;
+				const error = new Error(message);
+				this.emit("error", error);
+				return;
+			}
+
+			const finalText = renderFinalTokenText(response.tokens ?? []);
+			if (!finalText) return;
+
+			this.transcriptChunks.push(finalText);
+			const event: LiveTranscriptEvent = {
+				text: finalText,
+				isFinal: true,
+				speechFinal: true,
+			};
+			this.emit("transcript", finalText, event);
+		} catch (error) {
+			logError("Failed to parse Soniox streaming response", error);
+		}
+	}
+
+	private flushBuffer(): void {
+		if (!this.connection || !this.isConnected) return;
+
+		for (const chunk of this.audioBuffer) {
+			this.connection.send(chunk);
+			this.chunksSent++;
+		}
+		this.audioBuffer = [];
+	}
+
+	private waitForClose(): Promise<boolean> {
+		return new Promise((resolve) => {
+			const timeout = setTimeout(() => {
+				resolve(false);
+			}, SONIOX_CLOSE_TIMEOUT_MS);
+
+			this.once("close", () => {
+				clearTimeout(timeout);
+				resolve(true);
+			});
+		});
+	}
+}
+
+function renderFinalTokenText(tokens: SonioxToken[]): string {
+	return tokens
+		.filter((token) => token.is_final && token.text)
+		.map((token) => token.text)
+		.join("");
+}

--- a/src/transcribe/soniox-streaming.ts
+++ b/src/transcribe/soniox-streaming.ts
@@ -272,10 +272,13 @@ export class SonioxStreamingTranscriber
 const SONIOX_STRIP_PATTERN = /<\|?end\|?>|<\|?start\|?>|<\|\d+\.\d+\|>/g;
 
 function renderFinalTokenText(tokens: SonioxToken[]): string {
-	return tokens
+	const text = tokens
 		.filter((token) => token.is_final && token.text)
 		.map((token) => (token.text ?? "").replace(SONIOX_STRIP_PATTERN, ""))
-		.join("")
+		.join("");
+
+	return text
+		.replace(/ ([,.\u00!?;:'"%)])/g, "$1")
 		.replace(/  +/g, " ")
 		.trim();
 }

--- a/src/transcribe/soniox-streaming.ts
+++ b/src/transcribe/soniox-streaming.ts
@@ -39,11 +39,19 @@ interface SonioxWebSocketLike {
 
 type CreateSonioxWebSocket = (url: string) => SonioxWebSocketLike;
 
+interface SonioxContextGeneralEntry {
+	key: string;
+	value: string;
+}
+
 interface SonioxStreamingTranscriberOptions {
 	apiKey?: string;
 	endpoint?: string;
 	createWebSocket?: CreateSonioxWebSocket;
 	paragraphPauseMs?: number;
+	languageHintsStrict?: boolean;
+	contextGeneral?: SonioxContextGeneralEntry[];
+	contextText?: string;
 }
 
 export class SonioxStreamingTranscriber
@@ -54,6 +62,9 @@ export class SonioxStreamingTranscriber
 	private readonly endpoint: string;
 	private readonly createWebSocket: CreateSonioxWebSocket;
 	private readonly paragraphPauseMs: number;
+	private readonly languageHintsStrict: boolean;
+	private readonly contextGeneral: SonioxContextGeneralEntry[];
+	private readonly contextText: string;
 	private connection: SonioxWebSocketLike | null = null;
 	private transcriptChunks: string[] = [];
 	private audioBuffer: Buffer[] = [];
@@ -75,6 +86,9 @@ export class SonioxStreamingTranscriber
 		this.apiKey = apiKey;
 		this.endpoint = options.endpoint ?? SONIOX_WEBSOCKET_ENDPOINT;
 		this.paragraphPauseMs = options.paragraphPauseMs ?? 3000;
+		this.languageHintsStrict = options.languageHintsStrict ?? true;
+		this.contextGeneral = options.contextGeneral ?? [];
+		this.contextText = options.contextText ?? "";
 		this.createWebSocket =
 			options.createWebSocket ??
 			((url) => new WebSocket(url) as unknown as SonioxWebSocketLike);
@@ -106,10 +120,21 @@ export class SonioxStreamingTranscriber
 				num_channels: 1,
 				language_hints: [language],
 				enable_endpoint_detection: true,
+				language_hints_strict: this.languageHintsStrict,
 			};
 
+			const context: Record<string, unknown> = {};
 			if (boostWords.length > 0) {
-				config.context = { terms: boostWords };
+				context.terms = boostWords;
+			}
+			if (this.contextGeneral.length > 0) {
+				context.general = this.contextGeneral;
+			}
+			if (this.contextText.length > 0) {
+				context.text = this.contextText;
+			}
+			if (Object.keys(context).length > 0) {
+				config.context = context;
 			}
 
 			this.connection.send(JSON.stringify(config));
@@ -283,7 +308,7 @@ function renderFinalTokenText(tokens: SonioxToken[]): string {
 		.join("");
 
 	return text
-		.replace(/ ([,.\u00!?;:'"%)])/g, "$1")
+		.replace(/ ([,.\u0021!?;:'"%)])/g, "$1")
 		.replace(/  +/g, " ")
 		.trim();
 }

--- a/src/transcribe/soniox-streaming.ts
+++ b/src/transcribe/soniox-streaming.ts
@@ -272,12 +272,12 @@ export class SonioxStreamingTranscriber
 const SONIOX_STRIP_PATTERN = /<\|?end\|?>|<\|?start\|?>|<\|\d+\.\d+\|>/g;
 
 function renderFinalTokenText(tokens: SonioxToken[]): string {
-	const text = tokens
+	return tokens
 		.filter((token) => token.is_final && token.text)
 		.map((token) => (token.text ?? "").replace(SONIOX_STRIP_PATTERN, ""))
-		.join(" ");
-
-	return text.replace(/  +/g, " ").trim();
+		.join("")
+		.replace(/  +/g, " ")
+		.trim();
 }
 
 const LLM_FORMAT_SYSTEM_PROMPT = `Task: add paragraph breaks to raw dictation text.

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -23,6 +23,7 @@ describe("Config Loader", () => {
 		delete process.env.GROQ_API_KEY;
 		delete process.env.GROQ_FALLBACK_API_KEY;
 		delete process.env.DEEPGRAM_API_KEY;
+		delete process.env.SONIOX_API_KEY;
 		vi.clearAllMocks();
 	});
 
@@ -49,6 +50,10 @@ describe("Config Loader", () => {
 		expect(config.apiKeys.deepgram).toBe(
 			"4b5c1234-5678-90ab-cdef-1234567890ab",
 		);
+		expect(config.apiKeys.soniox).toBeUndefined();
+		expect(config.liveDictation.enabled).toBe(false);
+		expect(config.liveDictation.insertionCommand).toBe("auto");
+		expect(config.liveDictation.soniox.enabled).toBe(false);
 	});
 
 	test("should load fallback Groq API key from env if missing in file", () => {
@@ -64,6 +69,21 @@ describe("Config Loader", () => {
 
 		const config = loadConfig(CONFIG_FILE, true);
 		expect(config.apiKeys.groqFallback).toBe("gsk_env_fallback_12345");
+	});
+
+	test("should load optional Soniox API key from env", () => {
+		const configData = {
+			apiKeys: {
+				groq: "gsk_1234567890",
+				deepgram: "4b5c1234-5678-90ab-cdef-1234567890ab",
+			},
+		};
+		writeFileSync(CONFIG_FILE, JSON.stringify(configData));
+		chmodSync(CONFIG_FILE, 0o600);
+		process.env.SONIOX_API_KEY = "soniox_test_key";
+
+		const config = loadConfig(CONFIG_FILE, true);
+		expect(config.apiKeys.soniox).toBe("soniox_test_key");
 	});
 
 	test("should load config when file does not exist (env fallback)", () => {
@@ -538,5 +558,26 @@ describe("Config Loader", () => {
 
 			expect(() => loadConfig(CONFIG_FILE)).toThrow("Invalid hotkey format");
 		}
+	});
+
+	test("should reject invalid Soniox provider bypass trigger key", () => {
+		const configData = {
+			apiKeys: {
+				groq: "gsk_1234567890",
+				deepgram: "4b5c1234-5678-90ab-cdef-1234567890ab",
+			},
+			liveDictation: {
+				soniox: {
+					enabled: true,
+					triggerKey: "Definitely Not A Key",
+				},
+			},
+		};
+		writeFileSync(CONFIG_FILE, JSON.stringify(configData));
+		chmodSync(CONFIG_FILE, 0o600);
+
+		expect(() => loadConfig(CONFIG_FILE)).toThrow(
+			"Invalid Soniox trigger key format",
+		);
 	});
 });

--- a/tests/hotkey-bindings.test.ts
+++ b/tests/hotkey-bindings.test.ts
@@ -22,9 +22,11 @@ function hotkeyConfig(
 		liveDictation: {
 			enabled: true,
 			insertionCommand: "auto",
+			retypeFormatted: true,
 			soniox: {
 				enabled: sonioxEnabled,
 				triggerKey: "Right Alt",
+				paragraphPauseMs: 3000,
 			},
 		},
 	};

--- a/tests/hotkey-bindings.test.ts
+++ b/tests/hotkey-bindings.test.ts
@@ -27,6 +27,12 @@ function hotkeyConfig(
 				enabled: sonioxEnabled,
 				triggerKey: "Right Alt",
 				paragraphPauseMs: 3000,
+				languageHintsStrict: true,
+				contextGeneral: [
+					{ key: "domain", value: "software development" },
+					{ key: "topic", value: "technical architecture and implementation" },
+				],
+				contextText: "The speaker is dictating technical prompts for AI coding agents, software architecture discussions, code comments, and developer workflow instructions. Content includes programming terminology, API references, database schemas, CLI commands, and system administration tasks.",
 			},
 		},
 	};

--- a/tests/hotkey-bindings.test.ts
+++ b/tests/hotkey-bindings.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import type { Config } from "../src/config/schema";
+import {
+	createHotkeyBindings,
+	matchesHotkeyBinding,
+} from "../src/daemon/hotkey";
+
+function hotkeyConfig(
+	sonioxEnabled: boolean,
+): Pick<Config, "behavior" | "liveDictation"> {
+	return {
+		behavior: {
+			hotkey: "Right Control",
+			toggleMode: true,
+			notifications: true,
+			clipboard: {
+				append: true,
+				minDuration: 0.6,
+				maxDuration: 600,
+			},
+		},
+		liveDictation: {
+			enabled: true,
+			insertionCommand: "auto",
+			soniox: {
+				enabled: sonioxEnabled,
+				triggerKey: "Right Alt",
+			},
+		},
+	};
+}
+
+describe("hotkey bindings", () => {
+	test("keeps only the default binding when Soniox bypass is disabled", () => {
+		const bindings = createHotkeyBindings(hotkeyConfig(false));
+
+		expect(bindings.map((binding) => binding.event)).toEqual(["trigger"]);
+	});
+
+	test("adds a separate Soniox trigger binding when enabled", () => {
+		const bindings = createHotkeyBindings(hotkeyConfig(true));
+
+		expect(bindings.map((binding) => binding.event)).toEqual([
+			"trigger",
+			"soniox-trigger",
+		]);
+		expect(bindings[1]).toMatchObject({
+			hotkey: "RIGHT ALT",
+			triggerKey: "RIGHT ALT",
+			modifiers: [],
+		});
+	});
+
+	test("matches modifier chords without firing the Soniox binding", () => {
+		const [defaultBinding, sonioxBinding] = createHotkeyBindings({
+			...hotkeyConfig(true),
+			behavior: {
+				...hotkeyConfig(true).behavior,
+				hotkey: "Ctrl+Space",
+			},
+		});
+		if (!defaultBinding || !sonioxBinding) {
+			throw new Error("Expected default and Soniox hotkey bindings");
+		}
+
+		expect(
+			matchesHotkeyBinding(defaultBinding, "SPACE", { "LEFT CTRL": true }),
+		).toBe(true);
+		expect(
+			matchesHotkeyBinding(sonioxBinding, "SPACE", { "LEFT CTRL": true }),
+		).toBe(false);
+	});
+});

--- a/tests/live-dictation.test.ts
+++ b/tests/live-dictation.test.ts
@@ -56,6 +56,42 @@ describe("LiveDictationWriter", () => {
 		]);
 	});
 
+	test("selectLineAndType on Wayland uses Home+Shift+End escape sequences", async () => {
+		const commands: Array<{ command: string; args: string[] }> = [];
+		const typer = new DesktopTextTyper({
+			env: { WAYLAND_DISPLAY: "wayland-1" },
+			isCommandAvailable: (command) => command === "wtype",
+			runCommand: async (command, args) => {
+				commands.push({ command, args });
+			},
+		});
+
+		await typer.selectLineAndType("hello world");
+
+		expect(commands).toEqual([
+			{ command: "wtype", args: ["--", "\x1b[H\x1b[1;2F"] },
+			{ command: "wtype", args: ["hello world"] },
+		]);
+	});
+
+	test("selectLineAndType on X11 uses Home+Shift+End via xdotool", async () => {
+		const commands: Array<{ command: string; args: string[] }> = [];
+		const typer = new DesktopTextTyper({
+			env: {},
+			isCommandAvailable: (command) => command === "xdotool",
+			runCommand: async (command, args) => {
+				commands.push({ command, args });
+			},
+		});
+
+		await typer.selectLineAndType("hello x11");
+
+		expect(commands).toEqual([
+			{ command: "xdotool", args: ["key", "--clearmodifiers", "Home", "shift+End"] },
+			{ command: "xdotool", args: ["type", "--clearmodifiers", "--", "hello x11"] },
+		]);
+	});
+
 	test("honors an explicit focused text insertion command", async () => {
 		const commands: Array<{ command: string; args: string[] }> = [];
 		const typer = new DesktopTextTyper({

--- a/tests/live-dictation.test.ts
+++ b/tests/live-dictation.test.ts
@@ -69,7 +69,7 @@ describe("LiveDictationWriter", () => {
 		await typer.selectLineAndType("hello world");
 
 		expect(commands).toEqual([
-			{ command: "wtype", args: ["--", "\x1b[H\x1b[1;2F"] },
+			{ command: "wtype", args: ["-k", "Home", "-M", "shift", "-k", "End", "-m", "shift"] },
 			{ command: "wtype", args: ["hello world"] },
 		]);
 	});

--- a/tests/live-dictation.test.ts
+++ b/tests/live-dictation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import {
+	DesktopTextTyper,
+	LiveDictationWriter,
+} from "../src/output/live-dictation";
+
+describe("LiveDictationWriter", () => {
+	test("types only the newly committed transcript delta", async () => {
+		const typed: string[] = [];
+		const writer = new LiveDictationWriter({
+			typeText: async (text) => {
+				typed.push(text);
+			},
+		});
+
+		await writer.acceptCommittedTranscript("hello");
+		await writer.acceptCommittedTranscript("hello world");
+		await writer.acceptCommittedTranscript("hello world");
+		await writer.acceptCommittedTranscript("hello world again");
+
+		expect(typed).toEqual(["hello", " world", " again"]);
+	});
+
+	test("uses wtype for focused text insertion on Wayland", async () => {
+		const commands: Array<{ command: string; args: string[] }> = [];
+		const typer = new DesktopTextTyper({
+			env: { WAYLAND_DISPLAY: "wayland-1" },
+			isCommandAvailable: (command) => command === "wtype",
+			runCommand: async (command, args) => {
+				commands.push({ command, args });
+			},
+		});
+
+		await typer.typeText("hello world");
+
+		expect(commands).toEqual([{ command: "wtype", args: ["hello world"] }]);
+	});
+
+	test("uses xdotool for focused text insertion outside Wayland", async () => {
+		const commands: Array<{ command: string; args: string[] }> = [];
+		const typer = new DesktopTextTyper({
+			env: {},
+			isCommandAvailable: (command) => command === "xdotool",
+			runCommand: async (command, args) => {
+				commands.push({ command, args });
+			},
+		});
+
+		await typer.typeText("hello x11");
+
+		expect(commands).toEqual([
+			{
+				command: "xdotool",
+				args: ["type", "--clearmodifiers", "--", "hello x11"],
+			},
+		]);
+	});
+});

--- a/tests/live-dictation.test.ts
+++ b/tests/live-dictation.test.ts
@@ -55,4 +55,22 @@ describe("LiveDictationWriter", () => {
 			},
 		]);
 	});
+
+	test("honors an explicit focused text insertion command", async () => {
+		const commands: Array<{ command: string; args: string[] }> = [];
+		const typer = new DesktopTextTyper({
+			preferredCommand: "wtype",
+			env: {},
+			isCommandAvailable: (command) => command === "wtype",
+			runCommand: async (command, args) => {
+				commands.push({ command, args });
+			},
+		});
+
+		await typer.typeText("forced wayland command");
+
+		expect(commands).toEqual([
+			{ command: "wtype", args: ["forced wayland command"] },
+		]);
+	});
 });

--- a/tests/live-provider.test.ts
+++ b/tests/live-provider.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import {
+	isCommittedLiveTranscript,
+	type LiveTranscriptEvent,
+} from "../src/transcribe/live-provider";
+
+describe("live provider transcript events", () => {
+	test("commits only final or speech-final transcript events", () => {
+		const interim: LiveTranscriptEvent = {
+			text: "hello wor",
+			isFinal: false,
+			speechFinal: false,
+		};
+		const finalChunk: LiveTranscriptEvent = {
+			text: "hello world",
+			isFinal: true,
+			speechFinal: false,
+		};
+		const speechFinalChunk: LiveTranscriptEvent = {
+			text: "hello again",
+			isFinal: false,
+			speechFinal: true,
+		};
+
+		expect(isCommittedLiveTranscript(interim)).toBe(false);
+		expect(isCommittedLiveTranscript(finalChunk)).toBe(true);
+		expect(isCommittedLiveTranscript(speechFinalChunk)).toBe(true);
+	});
+});

--- a/tests/recording-session-live-dictation.test.ts
+++ b/tests/recording-session-live-dictation.test.ts
@@ -1,0 +1,42 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, test } from "vitest";
+import { attachLiveDictationTranscriptHandler } from "../src/daemon/recording-session";
+import type { TextTyper } from "../src/output/live-dictation";
+import type { LiveTranscriptEvent } from "../src/transcribe/live-provider";
+
+describe("recording session live dictation", () => {
+	test("types only committed provider transcript events", async () => {
+		const provider = new EventEmitter();
+		const typed: string[] = [];
+		const typer: TextTyper = {
+			typeText: async (text) => {
+				typed.push(text);
+			},
+		};
+
+		attachLiveDictationTranscriptHandler({
+			provider,
+			typer,
+		});
+
+		provider.emit("transcript", "hello wor", {
+			text: "hello wor",
+			isFinal: false,
+			speechFinal: false,
+		} satisfies LiveTranscriptEvent);
+		provider.emit("transcript", "hello world", {
+			text: "hello world",
+			isFinal: true,
+			speechFinal: false,
+		} satisfies LiveTranscriptEvent);
+		provider.emit("transcript", "hello world again", {
+			text: "hello world again",
+			isFinal: false,
+			speechFinal: true,
+		} satisfies LiveTranscriptEvent);
+
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(typed).toEqual(["hello world", " again"]);
+	});
+});

--- a/tests/soniox-streaming.test.ts
+++ b/tests/soniox-streaming.test.ts
@@ -111,7 +111,7 @@ describe("SonioxStreamingTranscriber", () => {
 			}),
 		);
 
-		expect(events).toEqual(["hello ", "world!"]);
+		expect(events).toEqual(["hello", "world !"]);
 	});
 
 	test("sends an empty frame on stop and returns the final transcript", async () => {
@@ -137,6 +137,179 @@ describe("SonioxStreamingTranscriber", () => {
 		expect(socket.sent).toContain("");
 		expect(result.text).toBe("done");
 		expect(result.chunkCount).toBe(1);
+		expect(result.paragraphBreakCount).toBe(0);
 		expect(result.stopReason).toBe("finalize_transcript");
+	});
+
+	test("joins tokens with spaces and collapses double spaces", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+		});
+		const events: string[] = [];
+		transcriber.on("transcript", (text) => events.push(text));
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+		socket.receive(
+			JSON.stringify({
+				tokens: [
+					{ text: "hello", is_final: true },
+					{ text: "  ", is_final: true },
+					{ text: "world", is_final: true },
+				],
+			}),
+		);
+
+		expect(events).toEqual(["hello world"]);
+	});
+
+	test("inserts double-space paragraph break on long pause", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+			paragraphPauseMs: 100,
+		});
+		const events: string[] = [];
+		transcriber.on("transcript", (text) => events.push(text));
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+
+		socket.receive(
+			JSON.stringify({
+				tokens: [{ text: "first sentence", is_final: true }],
+			}),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 150));
+
+		socket.receive(
+			JSON.stringify({
+				tokens: [{ text: "second sentence", is_final: true }],
+			}),
+		);
+
+		expect(events.length).toBe(2);
+		expect(events[1]).toContain("  ");
+	});
+
+	test("does not insert paragraph break on short pause", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+			paragraphPauseMs: 5000,
+		});
+		const events: string[] = [];
+		transcriber.on("transcript", (text) => events.push(text));
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+
+		socket.receive(
+			JSON.stringify({
+				tokens: [{ text: "first", is_final: true }],
+			}),
+		);
+
+		socket.receive(
+			JSON.stringify({
+				tokens: [{ text: "second", is_final: true }],
+			}),
+		);
+
+		expect(events.length).toBe(2);
+		expect(events[1]).not.toContain("  ");
+	});
+
+	test("includes paragraphBreakCount in stop result", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+			paragraphPauseMs: 100,
+		});
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+
+		socket.receive(
+			JSON.stringify({
+				tokens: [{ text: "first", is_final: true }],
+			}),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 150));
+
+		socket.receive(
+			JSON.stringify({
+				tokens: [{ text: "second", is_final: true }],
+			}),
+		);
+
+		const resultPromise = transcriber.stop();
+		socket.close();
+		const result = await resultPromise;
+
+		expect(result.paragraphBreakCount).toBe(1);
+	});
+
+	test("resets paragraphBreakCount on start", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+			paragraphPauseMs: 100,
+		});
+
+		await transcriber.start("en");
+		const socket1 = getSocket();
+		socket1.open();
+
+		socket1.receive(
+			JSON.stringify({
+				tokens: [{ text: "first", is_final: true }],
+			}),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 150));
+
+		socket1.receive(
+			JSON.stringify({
+				tokens: [{ text: "second", is_final: true }],
+			}),
+		);
+
+		const result1 = await (async () => {
+			const p = transcriber.stop();
+			socket1.close();
+			return p;
+		})();
+
+		expect(result1.paragraphBreakCount).toBe(1);
+
+		MockSonioxWebSocket.instances = [];
+		await transcriber.start("en");
+		const socket2 = getSocket();
+		socket2.open();
+
+		socket2.receive(
+			JSON.stringify({
+				tokens: [{ text: "fresh", is_final: true }],
+			}),
+		);
+
+		const result2Promise = transcriber.stop();
+		socket2.close();
+		const result2 = await result2Promise;
+
+		expect(result2.paragraphBreakCount).toBe(0);
 	});
 });

--- a/tests/soniox-streaming.test.ts
+++ b/tests/soniox-streaming.test.ts
@@ -111,7 +111,7 @@ describe("SonioxStreamingTranscriber", () => {
 			}),
 		);
 
-		expect(events).toEqual(["hello", "world !"]);
+		expect(events).toEqual(["hello", "world!"]);
 	});
 
 	test("sends an empty frame on stop and returns the final transcript", async () => {

--- a/tests/soniox-streaming.test.ts
+++ b/tests/soniox-streaming.test.ts
@@ -340,4 +340,22 @@ describe("SonioxStreamingTranscriber", () => {
 
 		expect(result2.paragraphBreakCount).toBe(0);
 	});
+
+	test("sends boost words as context.terms in config message", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+		});
+
+		await transcriber.start("en", ["Hyprvox", "Groq", "Deepgram"]);
+		const socket = getSocket();
+		socket.open();
+
+		const configMessage = JSON.parse(String(socket.sent[0]));
+		expect(configMessage.context).toBeDefined();
+		expect(configMessage.context.terms).toEqual(["Hyprvox", "Groq", "Deepgram"]);
+
+		socket.close();
+	});
 });

--- a/tests/soniox-streaming.test.ts
+++ b/tests/soniox-streaming.test.ts
@@ -358,4 +358,110 @@ describe("SonioxStreamingTranscriber", () => {
 
 		socket.close();
 	});
+
+	test("sends language_hints_strict in config message", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+			languageHintsStrict: true,
+		});
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+
+		const configMessage = JSON.parse(String(socket.sent[0]));
+		expect(configMessage.language_hints_strict).toBe(true);
+
+		socket.close();
+	});
+
+	test("sends context.general in config message", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+			contextGeneral: [
+				{ key: "domain", value: "software development" },
+				{ key: "topic", value: "technical architecture" },
+			],
+		});
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+
+		const configMessage = JSON.parse(String(socket.sent[0]));
+		expect(configMessage.context).toBeDefined();
+		expect(configMessage.context.general).toEqual([
+			{ key: "domain", value: "software development" },
+			{ key: "topic", value: "technical architecture" },
+		]);
+
+		socket.close();
+	});
+
+	test("sends context.text in config message", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+			contextText: "Dictating technical prompts for AI agents.",
+		});
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+
+		const configMessage = JSON.parse(String(socket.sent[0]));
+		expect(configMessage.context).toBeDefined();
+		expect(configMessage.context.text).toBe("Dictating technical prompts for AI agents.");
+
+		socket.close();
+	});
+
+	test("combines all context fields in config message", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+			languageHintsStrict: true,
+			contextGeneral: [{ key: "domain", value: "software development" }],
+			contextText: "Technical dictation context.",
+		});
+
+		await transcriber.start("en", ["Hyprvox"]);
+		const socket = getSocket();
+		socket.open();
+
+		const configMessage = JSON.parse(String(socket.sent[0]));
+		expect(configMessage.language_hints_strict).toBe(true);
+		expect(configMessage.context.terms).toEqual(["Hyprvox"]);
+		expect(configMessage.context.general).toEqual([
+			{ key: "domain", value: "software development" },
+		]);
+		expect(configMessage.context.text).toBe("Technical dictation context.");
+
+		socket.close();
+	});
+
+	test("omits context when no context fields are provided", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+			contextGeneral: [],
+			contextText: "",
+		});
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+
+		const configMessage = JSON.parse(String(socket.sent[0]));
+		expect(configMessage.context).toBeUndefined();
+
+		socket.close();
+	});
 });

--- a/tests/soniox-streaming.test.ts
+++ b/tests/soniox-streaming.test.ts
@@ -166,6 +166,34 @@ describe("SonioxStreamingTranscriber", () => {
 		expect(events).toEqual(["hello world"]);
 	});
 
+	test("strips spaces before punctuation", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+		});
+		const events: string[] = [];
+		transcriber.on("transcript", (text) => events.push(text));
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+		socket.receive(
+			JSON.stringify({
+				tokens: [
+					{ text: "world ", is_final: true },
+					{ text: ", ", is_final: true },
+					{ text: "test ", is_final: true },
+					{ text: ". ", is_final: true },
+					{ text: "Hello ", is_final: true },
+					{ text: "! ", is_final: true },
+				],
+			}),
+		);
+
+		expect(events).toEqual(["world, test. Hello!"]);
+	});
+
 	test("inserts double-space paragraph break on long pause", async () => {
 		MockSonioxWebSocket.instances = [];
 		const transcriber = new SonioxStreamingTranscriber({

--- a/tests/soniox-streaming.test.ts
+++ b/tests/soniox-streaming.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "vitest";
+import { SonioxStreamingTranscriber } from "../src/transcribe/soniox-streaming";
+
+class MockSonioxWebSocket {
+	public static instances: MockSonioxWebSocket[] = [];
+	public readyState = 0;
+	public onopen: (() => void) | null = null;
+	public onmessage: ((event: { data: unknown }) => void) | null = null;
+	public onerror: ((event: unknown) => void) | null = null;
+	public onclose: (() => void) | null = null;
+	public readonly sent: Array<string | Buffer> = [];
+
+	public constructor(public readonly url: string) {
+		MockSonioxWebSocket.instances.push(this);
+	}
+
+	public send(data: string | Buffer): void {
+		this.sent.push(data);
+	}
+
+	public close(): void {
+		this.readyState = 3;
+		this.onclose?.();
+	}
+
+	public open(): void {
+		this.readyState = 1;
+		this.onopen?.();
+	}
+
+	public receive(data: unknown): void {
+		this.onmessage?.({ data });
+	}
+}
+
+function getSocket(): MockSonioxWebSocket {
+	const socket = MockSonioxWebSocket.instances[0];
+	if (!socket) {
+		throw new Error("Expected Soniox websocket to be created");
+	}
+	return socket;
+}
+
+describe("SonioxStreamingTranscriber", () => {
+	test("starts a Soniox websocket session with raw PCM config", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+		});
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+
+		expect(socket.url).toBe("wss://stt-rt.soniox.com/transcribe-websocket");
+		expect(JSON.parse(String(socket.sent[0]))).toMatchObject({
+			api_key: "soniox-test-key",
+			model: "stt-rt-v5",
+			audio_format: "pcm_s16le",
+			sample_rate: 16000,
+			num_channels: 1,
+			language_hints: ["en"],
+			enable_endpoint_detection: true,
+		});
+	});
+
+	test("buffers audio until the websocket opens", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+		});
+		const audioChunk = Buffer.from([1, 2, 3]);
+
+		await transcriber.start("en");
+		transcriber.send(audioChunk);
+		const socket = getSocket();
+		socket.open();
+
+		expect(socket.sent.at(-1)).toBe(audioChunk);
+	});
+
+	test("emits committed transcript events for final Soniox tokens only", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+		});
+		const events: string[] = [];
+		transcriber.on("transcript", (text) => events.push(text));
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+		socket.receive(
+			JSON.stringify({
+				tokens: [
+					{ text: "hello", is_final: true },
+					{ text: " ", is_final: true },
+					{ text: "wor", is_final: false },
+				],
+			}),
+		);
+		socket.receive(
+			JSON.stringify({
+				tokens: [
+					{ text: "world", is_final: true },
+					{ text: "!", is_final: true },
+				],
+			}),
+		);
+
+		expect(events).toEqual(["hello ", "world!"]);
+	});
+
+	test("sends an empty frame on stop and returns the final transcript", async () => {
+		MockSonioxWebSocket.instances = [];
+		const transcriber = new SonioxStreamingTranscriber({
+			apiKey: "soniox-test-key",
+			createWebSocket: (url) => new MockSonioxWebSocket(url),
+		});
+
+		await transcriber.start("en");
+		const socket = getSocket();
+		socket.open();
+		socket.receive(
+			JSON.stringify({
+				tokens: [{ text: "done", is_final: true }],
+			}),
+		);
+
+		const resultPromise = transcriber.stop();
+		socket.close();
+		const result = await resultPromise;
+
+		expect(socket.sent).toContain("");
+		expect(result.text).toBe("done");
+		expect(result.chunkCount).toBe(1);
+		expect(result.stopReason).toBe("finalize_transcript");
+	});
+});


### PR DESCRIPTION
## Summary
- add live dictation text insertion for committed streaming transcript events
- add optional Soniox API key/config plus a Soniox real-time WebSocket provider
- add a separate Soniox bypass hotkey path that streams recorder PCM directly to Soniox, types final tokens, and writes final transcript to clipboard/history without Groq/Deepgram merge
- document live dictation and Soniox configuration/flow

## Validation
- bunx vitest run -c vitest.config.ts tests/live-dictation.test.ts tests/recording-session-live-dictation.test.ts tests/live-provider.test.ts tests/config.test.ts tests/soniox-streaming.test.ts tests/hotkey-bindings.test.ts
- bunx tsc --noEmit -p tsconfig.json
- git diff --check
- bun run index.ts health after restarting hyprvox.service

## Notes
- Local config currently has no Soniox key and no liveDictation block, so Soniox network transcription was not manually exercised locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Live Dictation with committed-only incremental typing, pause-based paragraph breaks, and optional post-stop retyping.
  * Added a Soniox provider-bypass live dictation flow with its own trigger and minimal stop formatting.
  * Added a `soniox-toggle` CLI command and support for multiple hotkey bindings.
* **Bug Fixes**
  * Reduced flicker/duplication via committed segment typing and improved spacing/paragraph-break normalization.
* **Documentation**
  * Updated configuration and live transcription docs, including `SONIOX_API_KEY` fallback and new PRD/issue breakdowns.
* **Tests**
  * Added coverage for live dictation typing, commitment detection, Soniox streaming/formatting, and paragraph logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->