### PR TITLE
ci: build the overlay so type errors cannot ship

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,22 @@ jobs:
       - name: Run tests
         run: bun test
 
+      # The overlay is a separate npm project with its own tsconfig, so neither
+      # the root typecheck nor the tests above cover it. Its build is
+      # `tsc && vite build`, so this catches type errors that would otherwise
+      # ship a release whose overlay cannot be built at all.
+      - name: Install overlay dependencies
+        working-directory: overlay
+        run: npm install --no-audit --no-fund
+        env:
+          # CI only typechecks and bundles the renderer; it never launches
+          # Electron, so skip the ~100MB binary download.
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Build overlay
+        working-directory: overlay
+        run: npm run build
+
       - name: Pack package
         run: bun x npm pack
 


### PR DESCRIPTION
The overlay is a separate npm project with its own tsconfig, so neither the root typecheck nor the test job covered it. A type error that broke its build outright reached `main` and shipped as **v0.19.0** with CI reporting green throughout.

Its build is `tsc && vite build`, so building it in CI is what catches this.

## Verified in a clean worktree (no pre-existing node_modules)

| Test | Result |
|---|---|
| `npm install` with Electron binary skipped | 469 packages, ~1 min |
| `npm run build` on fixed code | exit **0** |
| `npm run build` on the offending commit `d535653` | exit **2** |

The step demonstrably fails on the regression that shipped, rather than merely passing on good code.

Electron's binary download is skipped — CI only typechecks and bundles the renderer, and never launches Electron.

## Known limitation

The overlay has no lockfile, so this uses `npm install` rather than `npm ci` and is not fully reproducible. Committing a lockfile is a separate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended automated validation to include the overlay component’s dependency installation and production build.
  * CI now verifies the overlay builds successfully before packaging and smoke tests proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->